### PR TITLE
Issue with low performance due to recreating mapping collection

### DIFF
--- a/DocxTemplater/TemplateProcessor.cs
+++ b/DocxTemplater/TemplateProcessor.cs
@@ -84,7 +84,13 @@ namespace DocxTemplater
         private static void IsolateAndMergeTextTemplateMarkers(OpenXmlCompositeElement content)
         {
             var charMap = new CharacterMap(content);
-            foreach (var m in PatternMatcher.FindSyntaxPatterns(charMap.Text))
+        
+            var matches = PatternMatcher
+                .FindSyntaxPatterns(charMap.Text)
+                .OrderByDescending(m => m.Index)
+                .ToArray();
+        
+            foreach (var m in matches)
             {
                 var firstChar = charMap[m.Index];
                 var lastChar = charMap[m.Index + m.Length - 1];
@@ -92,8 +98,6 @@ namespace DocxTemplater
                 var lastText = lastChar.Element;
                 var mergedText = firstText.MergeText(firstChar.CharIndexInText, lastText, m.Length);
                 mergedText.Mark(m.Type);
-                // TODO: Ist this possible without recreate charMap?
-                charMap.Recreate();
             }
         }
 


### PR DESCRIPTION
I discovered the library works with my template for about 2 minutes. It has about 8k single placeholders for substitution. I don't fully understand why it was necessary to recreate the collection each time, but on my document, the speedup was about 200,000 times with no visible changes.