### PR TITLE
Net 10 - dropped net 6 and net 7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,9 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
+          10.x.x
           9.x.x
           8.x.x
-          7.x.x
-          6.x.x
 
     - name: Restore
       run: dotnet restore $SOLUTION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,9 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
+          10.x.x
           9.x.x
           8.x.x
-          7.x.x
-          6.x.x
 
     - name: Restore
       run: dotnet restore $SOLUTION

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
This pull request updates the project to support .NET 10.0 alongside existing versions. The main changes ensure that builds and releases include .NET 10.0 in both CI and release workflows, and the solution is now configured to target .NET 10.0 as well.

.NET 10.0 support:

* Updated the `TargetFrameworks` property in `Directory.Build.props` to include `net10.0`, allowing the project to build against .NET 10.0 in addition to .NET 8.0 and 9.0.

CI and release workflow updates:

* Modified the `.github/workflows/ci.yml` workflow to add `10.x.x` to the `dotnet-version` list, ensuring CI runs against .NET 10.0 and removing support for .NET 6.x and 7.x.
* Modified the `.github/workflows/release.yml` workflow to add `10.x.x` to the `dotnet-version` list, ensuring releases are built for .NET 10.0 and removing support for .NET 6.x and 7.x.