### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Amberg/DocxTemplater/security/code-scanning/1](https://github.com/Amberg/DocxTemplater/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block to the workflow file. Since the workflow mainly reads repository contents and pushes NuGet packages externally, the minimal required permission is likely `contents: read`. This block should be placed at the root level, just below the `name` (line 1) and before the `on` definition (line 2), or immediately after `on`. Doing so ensures all jobs inherit this minimal permission set unless they have their own explicit permissions block. No functionality will be affected—this change simply restricts what the workflow can do to the minimal safe set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
