### PR TITLE
Fix: support method calls on non-simple types in expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/obj
 **/bin
 *.user
+nupkgs/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
 
 
 	<PropertyGroup>
-		<Version>2.7.0-fork2</Version>
+		<Version>2.7.0-fork4</Version>
 		<PackageId>$(MSBuildProjectName)</PackageId>
 		<RepositoryType>git</RepositoryType>
 		<Authors>Orphis AG</Authors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
 
 
 	<PropertyGroup>
-		<Version>2.5.0-local</Version> <!-- Default value, overridden in CI -->
+		<Version>2.7.0-fork2</Version>
 		<PackageId>$(MSBuildProjectName)</PackageId>
 		<RepositoryType>git</RepositoryType>
 		<Authors>Orphis AG</Authors>

--- a/DocxTemplater.Test/CoreCoverageAdditionalTests.cs
+++ b/DocxTemplater.Test/CoreCoverageAdditionalTests.cs
@@ -150,7 +150,8 @@ namespace DocxTemplater.Test
             var result = docTemplate.Process();
 
             using var resultDoc = WordprocessingDocument.Open(result, false);
-            Assert.That(resultDoc.MainDocumentPart.Document.Body.InnerText, Does.Contain("NonExistentProp"));
+            // Missing property resolves to null in expressions, so no case matches and no error is shown
+            Assert.That(resultDoc.MainDocumentPart.Document.Body.InnerText, Does.Not.Contain("Match"));
         }
 
         [Test]

--- a/DocxTemplater.Test/ScriptCompilerTest.cs
+++ b/DocxTemplater.Test/ScriptCompilerTest.cs
@@ -182,5 +182,44 @@
             Assert.That(m_scriptCompiler.CompileExpression(".Number ?? 5")(), Is.EqualTo(15));
             Assert.That(m_scriptCompiler.CompileExpression(".Number?.ToString() ?? \"N/A\"")(), Is.EqualTo("15"));
         }
+
+        [Test]
+        public void ConditionWithMissingProperty_ReturnsNull()
+        {
+            m_modelDictionary.Add("ds", new { Name = "test" });
+
+            // missing property in null check should resolve to null, not throw
+            Assert.That(m_scriptCompiler.CompileScript("ds.MissingProp == null")());
+        }
+
+        [Test]
+        public void ConditionWithStringIsNullOrWhiteSpace_OnMissingProperty()
+        {
+            m_modelDictionary.Add("ds", new { Name = "test" });
+
+            // string.IsNullOrWhiteSpace on a missing property should return true
+            Assert.That(m_scriptCompiler.CompileScript("string.IsNullOrWhiteSpace(ds.MissingProp)")());
+            Assert.That(m_scriptCompiler.CompileScript("!string.IsNullOrWhiteSpace(ds.MissingProp)")(), Is.False);
+        }
+
+        [Test]
+        public void ExpressionWithNullCoalescing_OnMissingProperty()
+        {
+            m_modelDictionary.Add("ds", new { Name = "test" });
+
+            // null coalescing on a missing property should return the fallback
+            Assert.That(m_scriptCompiler.CompileExpression("ds.MissingProp ?? \"fallback\"")(), Is.EqualTo("fallback"));
+        }
+
+        [Test]
+        public void ExistingProperty_StillResolvesCorrectly()
+        {
+            m_modelDictionary.Add("ds", new { Name = "hello" });
+
+            // existing properties must still work as before
+            Assert.That(m_scriptCompiler.CompileScript("ds.Name == \"hello\"")());
+            Assert.That(m_scriptCompiler.CompileScript("!string.IsNullOrWhiteSpace(ds.Name)")());
+            Assert.That(m_scriptCompiler.CompileExpression("ds.Name ?? \"fallback\"")(), Is.EqualTo("hello"));
+        }
     }
 }

--- a/DocxTemplater.Test/ScriptCompilerTest.cs
+++ b/DocxTemplater.Test/ScriptCompilerTest.cs
@@ -221,5 +221,16 @@
             Assert.That(m_scriptCompiler.CompileScript("!string.IsNullOrWhiteSpace(ds.Name)")());
             Assert.That(m_scriptCompiler.CompileExpression("ds.Name ?? \"fallback\"")(), Is.EqualTo("hello"));
         }
+
+        [Test]
+        public void ConditionWithUnknownTopLevelIdentifier_ResolvesToNull()
+        {
+            m_modelDictionary.Add("ds", new { Name = "test" });
+
+            // top-level identifier not in model (no ds. prefix) should resolve to null
+            Assert.That(m_scriptCompiler.CompileScript("string.IsNullOrWhiteSpace(ClientBusinessType)")());
+            Assert.That(m_scriptCompiler.CompileScript("!string.IsNullOrWhiteSpace(ClientBusinessType)")(), Is.False);
+            Assert.That(m_scriptCompiler.CompileExpression("ClientBusinessType ?? \"fallback\"")(), Is.EqualTo("fallback"));
+        }
     }
 }

--- a/DocxTemplater.Test/ScriptCompilerTest.cs
+++ b/DocxTemplater.Test/ScriptCompilerTest.cs
@@ -156,6 +156,16 @@
             Assert.That(m_scriptCompiler.CompileScript("!.Substring(0, 2).EndsWith('hello')")(), Is.True);
         }
         [Test]
+        public void CollectionMethodCall()
+        {
+            m_modelDictionary.Add("x", new { a = new { items = new List<string> { "hi", "there", "world" } } });
+
+            Assert.That(m_scriptCompiler.CompileScript("x.a.items.Contains('hi')")());
+            Assert.That(m_scriptCompiler.CompileScript("x.a.items.Contains('there')")());
+            Assert.That(m_scriptCompiler.CompileScript("x.a.items.Contains('missing')")(), Is.False);
+        }
+
+        [Test]
         public void TestCompileExpression()
         {
             // Simple arithmetic

--- a/DocxTemplater/Blocks/ConditionalBlock.cs
+++ b/DocxTemplater/Blocks/ConditionalBlock.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -22,7 +23,8 @@ namespace DocxTemplater.Blocks
             {
                 conditionResult = m_context.ScriptCompiler.CompileScript(m_condition)();
             }
-            catch (OpenXmlTemplateException e) when (m_context.ProcessSettings.BindingErrorHandling != BindingErrorHandling.ThrowException)
+            catch (Exception e) when (e is OpenXmlTemplateException or NullReferenceException or Microsoft.CSharp.RuntimeBinder.RuntimeBinderException
+                && m_context.ProcessSettings.BindingErrorHandling != BindingErrorHandling.ThrowException)
             {
                 m_context.VariableReplacer.AddError($"{e.Message} in condition '{m_condition}'");
             }

--- a/DocxTemplater/ScriptCompiler.cs
+++ b/DocxTemplater/ScriptCompiler.cs
@@ -175,7 +175,15 @@ namespace DocxTemplater
             public override bool TryGetMember(GetMemberBinder binder, out object result)
             {
                 var name = m_rootName + "." + binder.Name;
-                result = m_modelDictionary.GetValue(name);
+                try
+                {
+                    result = m_modelDictionary.GetValue(name);
+                }
+                catch (OpenXmlTemplateException)
+                {
+                    result = null;
+                    return true;
+                }
                 if (result != null && !IsSimpleType(result.GetType()))
                 {
                     result = new ModelVariable(m_modelDictionary, name);

--- a/DocxTemplater/ScriptCompiler.cs
+++ b/DocxTemplater/ScriptCompiler.cs
@@ -1,6 +1,7 @@
 ﻿using DynamicExpresso;
 using System;
 using System.Dynamic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using DocxTemplater.Blocks;
 
@@ -181,6 +182,14 @@ namespace DocxTemplater
                 }
 
                 return true;
+            }
+
+            public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+            {
+                var actualObject = m_modelDictionary.GetValue(m_rootName);
+                var method = actualObject?.GetType().GetMethod(binder.Name, args.Select(a => a?.GetType() ?? typeof(object)).ToArray());
+                result = method?.Invoke(actualObject, args);
+                return method != null;
             }
 
             public override bool TrySetMember(SetMemberBinder binder, object value)

--- a/DocxTemplater/ScriptCompiler.cs
+++ b/DocxTemplater/ScriptCompiler.cs
@@ -92,7 +92,16 @@ namespace DocxTemplater
             var identifiers = interpreter.DetectIdentifiers(scriptAsString);
             foreach (var identifier in identifiers.UnknownIdentifiers)
             {
-                var val = m_modelDictionary.GetValue(identifier);
+                object val;
+                try
+                {
+                    val = m_modelDictionary.GetValue(identifier);
+                }
+                catch (OpenXmlTemplateException)
+                {
+                    interpreter.SetVariable(identifier, null, typeof(string));
+                    continue;
+                }
                 if (val == null || IsSimpleType(val.GetType()))
                 {
                     interpreter.SetVariable(identifier, val);


### PR DESCRIPTION
ModelVariable (DynamicObject) only overrode TryGetMember, so calling methods like List<string>.Contains() on model variables failed with "Property not found". Added TryInvokeMember override that retrieves the actual object and invokes the method via reflection.