### PR TITLE
Workitems/array index

### DIFF
--- a/DocxTemplater.Test/ExpressionBlockTest.cs
+++ b/DocxTemplater.Test/ExpressionBlockTest.cs
@@ -110,6 +110,86 @@ namespace DocxTemplater.Test
         }
 
         [Test]
+        public void ArrayIndexAccessInExpression()
+        {
+            using var memStream = new MemoryStream();
+            using var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document);
+            MainDocumentPart mainPart = wpDocument.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text("First: {{(ds.Items[0])}}")))));
+            wpDocument.Save();
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { Items = new[] { "a", "b", "c" } });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+
+            var document = WordprocessingDocument.Open(result, false);
+            var body = document.MainDocumentPart.Document.Body;
+            Assert.That(body.InnerText, Is.EqualTo("First: a"));
+        }
+
+        [Test]
+        public void ArrayIndexAccessOnComplexObject()
+        {
+            using var memStream = new MemoryStream();
+            using var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document);
+            MainDocumentPart mainPart = wpDocument.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text("Name: {{(ds.Items[1].Name)}}")))));
+            wpDocument.Save();
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { Items = new[] { new { Name = "first" }, new { Name = "second" } } });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+
+            var document = WordprocessingDocument.Open(result, false);
+            var body = document.MainDocumentPart.Document.Body;
+            Assert.That(body.InnerText, Is.EqualTo("Name: second"));
+        }
+
+        [Test]
+        public void IndexAccessOnListResultOfMethodCall()
+        {
+            using var memStream = new MemoryStream();
+            using var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document);
+            MainDocumentPart mainPart = wpDocument.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text(@"{{(ds.qa.Split('|')[0])}}")))));
+            wpDocument.Save();
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { qa = "question|answer" });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+
+            var document = WordprocessingDocument.Open(result, false);
+            var body = document.MainDocumentPart.Document.Body;
+            Assert.That(body.InnerText, Is.EqualTo("question"));
+        }
+
+        [Test]
+        public void DictionaryIndexAccessInExpression()
+        {
+            using var memStream = new MemoryStream();
+            using var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document);
+            MainDocumentPart mainPart = wpDocument.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text(@"{{(ds.Map[""key""])}}")))));
+            wpDocument.Save();
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { Map = new Dictionary<string, string> { ["key"] = "value" } });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+
+            var document = WordprocessingDocument.Open(result, false);
+            var body = document.MainDocumentPart.Document.Body;
+            Assert.That(body.InnerText, Is.EqualTo("value"));
+        }
+
+        [Test]
         public void AssignmentIsDisabled()
         {
             using var memStream = new MemoryStream();

--- a/DocxTemplater/ScriptCompiler.cs
+++ b/DocxTemplater/ScriptCompiler.cs
@@ -16,7 +16,8 @@ namespace DocxTemplater
                                                                         |                        
                                                                         (?<unary>[+\-!])         # Capture unary operators (+, -, !) in 'unary' group
                                                                         |                       
-                                                                        (?<=[^.\p{L}\p{N}_?])    # Position after any char that's not a dot, letter, number, underscore, or question mark (for null-conditional)
+                                                                        (?<=[^.\p{L}\p{N}_?\]])  # Position after any char that's not a dot, letter, number, underscore, question mark (for null-conditional)
+                                                                                                 # or closing bracket (a dot after ']' is member access on an index result, not an implicit scope)
                                                                                                  # (lookbehind - ensures we don't break existing identifiers or ?.)
 
                                                                         (?<!\(.*\))              # Also try to start after any function call with zero to many arguments.

--- a/DocxTemplater/ScriptCompilerModelVariable.cs
+++ b/DocxTemplater/ScriptCompilerModelVariable.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections;
 using System.Dynamic;
+using System.Linq;
+using System.Reflection;
 
 namespace DocxTemplater
 {
@@ -85,6 +88,61 @@ namespace DocxTemplater
         public override bool TrySetMember(SetMemberBinder binder, object value)
         {
             return false;
+        }
+
+        /// <summary>
+        /// Supports bracket indexing on the wrapped model value, e.g. <c>{{(ds.Items[0])}}</c>.
+        /// The actual collection is resolved from the model lookup and the raw indexed value is returned.
+        /// Note: any further access on the result (e.g. <c>items[0].Name</c>) is handled by the C# runtime
+        /// binder directly, not by <see cref="IModelLookup"/> - so model-specific resolution and
+        /// <see cref="BindingErrorHandling"/> do not apply beyond the index operation.
+        /// </summary>
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            object actualObject;
+            try
+            {
+                actualObject = m_modelDictionary.GetValue(m_rootName);
+            }
+            catch (OpenXmlTemplateException) when (ProcessSettings?.BindingErrorHandling is BindingErrorHandling.SkipBindingAndRemoveContent)
+            {
+                actualObject = null;
+            }
+
+            if (actualObject == null)
+            {
+                result = null;
+                return false;
+            }
+
+            result = GetIndexedValue(actualObject, indexes);
+            return true;
+        }
+
+        private static object GetIndexedValue(object target, object[] indexes)
+        {
+            switch (target)
+            {
+                case IDictionary dictionary when indexes.Length == 1:
+                    return dictionary[indexes[0]];
+                case IList list when indexes.Length == 1:
+                    return list[Convert.ToInt32(indexes[0])];
+            }
+
+            var indexer = target.GetType().GetDefaultMembers()
+                .OfType<PropertyInfo>()
+                .FirstOrDefault(p => p.GetIndexParameters().Length == indexes.Length);
+            if (indexer != null)
+            {
+                return indexer.GetValue(target, indexes);
+            }
+
+            if (indexes.Length == 1 && target is IEnumerable enumerable)
+            {
+                return enumerable.Cast<object>().ElementAt(Convert.ToInt32(indexes[0]));
+            }
+
+            throw new OpenXmlTemplateException($"Cannot apply indexing to an expression of type '{target.GetType()}'");
         }
 
         public override string ToString()

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The syntax is case insensitive.
 | `{{(ds.Name.ToUpper() + "!")}}`                          | Expressions with variables and string operations.                                               |
 | `{{(ds.Val?.ToString() ?? "N/A")}}`                      | Expressions with null-conditional and coalescing operators.                                     |
 | `{{(ds.Price * 1.19)}:f(c)}`                             | Expressions with calculations and formatters.                                                   |
+| `{{(ds.Items[0].Name)}}`                                 | Expressions with array / list / dictionary index access.                                        |
 | `{{SomeBytes}:img()}`                                    | Image Formatter for image data.                                                                 |
 | `{{SomeHtmlString}:html()}`                              | Inserts HTML string into the word document.                                                     |
 | `{{@i:ItemCount}}...{{i}}...{{/}}`                       | Range loop that repeats its content `ItemCount` times.                                          |
@@ -233,6 +234,19 @@ Expressions are evaluated using [DynamicExpresso](https://github.com/davideicard
 - **String Concatenation:** `{{(ds.Name.ToUpper() + "!")}}` -> `WORLD!` (if Name is "world")
 - **Null Handling:** `{{(ds.Val?.ToString() ?? "N/A")}}` -> `N/A` (if Val is null)
 - **Complex Logic:** `{{(ds.Items.Count > 0 ? "Items available" : "Empty")}}`
+- **Index Access:** `{{(ds.Items[0])}}` -> first element of a list, array or dictionary. Also works on method results, e.g. `{{(ds.Qa.Split('|')[0])}}`, and can be chained: `{{(ds.Items[1].Name)}}`.
+
+> [!TIP]
+> **Keep logic out of your templates.**
+> Expressions are handy for small calculations, but complex logic embedded in a document is hard to read, hard to test, and easy to break (Word also likes to rewrite quotes and operators).
+> For clean, maintainable templates prefer exposing a **property/getter with the logic on your model** and bind to that instead:
+> ```csharp
+> // Instead of {{(ds.Items[0].FirstName + " " + ds.Items[0].LastName)}}
+> public string PrimaryContactName => Items.Count > 0
+>     ? $"{Items[0].FirstName} {Items[0].LastName}"
+>     : "n/a";
+> ```
+> Then the template stays simple: `{{ds.PrimaryContactName}}`. The logic lives in C#, where it can be unit-tested and reused.
 
 #### Using Formatters with Expressions
 


### PR DESCRIPTION
This pull request adds support for array, list, and dictionary index access in template expressions, enabling syntax like `{{(ds.Items[0])}}` and `{{(ds.Map["key"])}}`. It introduces comprehensive tests for these scenarios, updates the template engine implementation to handle indexers, and improves documentation to describe the new capabilities and best practices.

**New expression features:**

* Added support for bracket indexing on arrays, lists, and dictionaries within template expressions (e.g., `{{(ds.Items[0])}}`, `{{(ds.Items[1].Name)}}`, `{{(ds.Map["key"])}}`, and index access on method results). This is implemented in `ScriptCompilerModelVariable` via the new `TryGetIndex` method and supporting logic.
* Updated the expression parsing logic in `ScriptCompiler` to correctly handle member access after a closing bracket (e.g., `Items[0].Name`).

**Testing improvements:**

* Added new unit tests in `ExpressionBlockTest.cs` to verify array, list, and dictionary index access, as well as index access on method results and chained member access.

**Documentation updates:**

* Updated the `README.md` to document the new index access syntax, provide usage examples, and add guidance on keeping logic out of templates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R237-R249)

**Implementation details:**

* Added necessary `using` directives for collections and reflection in `ScriptCompilerModelVariable.cs` to support the new indexing logic.