### PR TITLE
Template variable list

### DIFF
--- a/DocxTemplater.Test/ComplexTemplateTest.cs
+++ b/DocxTemplater.Test/ComplexTemplateTest.cs
@@ -16,6 +16,9 @@ namespace DocxTemplater.Test
             var model = CreateModel(imageBytes);
             docTemplate.BindModel("ds", model);
 
+
+            var shema = docTemplate.GetTemplateSchema();
+
             var result = docTemplate.Process();
             docTemplate.Validate();
             result.Position = 0;

--- a/DocxTemplater.Test/SchemaBuilderTest.cs
+++ b/DocxTemplater.Test/SchemaBuilderTest.cs
@@ -1,0 +1,175 @@
+using DocxTemplater.Schema;
+
+namespace DocxTemplater.Test
+{
+    [TestFixture]
+    internal sealed class SchemaBuilderTest
+    {
+        [Test]
+        public void DeclareScalar_AtRoot()
+        {
+            var b = new SchemaBuilder();
+            b.DeclareScalar("customer.Name");
+            var schema = b.Build();
+
+            Assert.That(schema.Roots.Keys, Is.EquivalentTo(["customer"]));
+            var customer = schema.Roots["customer"];
+            Assert.That(customer.Kind, Is.EqualTo(TemplateNodeKind.Object));
+            Assert.That(customer.Properties["Name"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void DeclareCollection_AtRoot()
+        {
+            var b = new SchemaBuilder();
+            var item = b.DeclareCollection("items");
+            b.OpenItemScope("items", item);
+            b.DeclareScalar("items.Price");
+            b.DeclareScalar("items.Name");
+            b.CloseScope();
+            var schema = b.Build();
+
+            var items = schema.Roots["items"];
+            Assert.That(items.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(items.ItemSchema, Is.Not.Null);
+            Assert.That(items.ItemSchema.Properties.Keys, Is.EquivalentTo(["Price", "Name"]));
+        }
+
+        [Test]
+        public void NestedCollection_DottedScopeKey()
+        {
+            var b = new SchemaBuilder();
+            var outerItem = b.DeclareCollection("customer.orders");
+            b.OpenItemScope("customer.orders", outerItem);
+            b.DeclareScalar("customer.orders.amount");
+            b.CloseScope();
+            var schema = b.Build();
+
+            var customer = schema.Roots["customer"];
+            var orders = customer.Properties["orders"];
+            Assert.That(orders.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(orders.ItemSchema.Properties["amount"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void OuterModelStillResolvesInsideLoop()
+        {
+            // Inside a loop on `items`, paths starting with `customer` (not the loop's name) must fall through to root.
+            var b = new SchemaBuilder();
+            var item = b.DeclareCollection("items");
+            b.OpenItemScope("items", item);
+            b.DeclareScalar("items.Price");
+            b.DeclareScalar("customer.Name");
+            b.CloseScope();
+            var schema = b.Build();
+
+            Assert.That(schema.Roots.Keys, Is.EquivalentTo(["items", "customer"]));
+            Assert.That(schema.Roots["customer"].Properties["Name"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void LeadingDot_ResolvesToInnerScope()
+        {
+            var b = new SchemaBuilder();
+            var item = b.DeclareCollection("items");
+            b.OpenItemScope("items", item);
+            // `.Price` inside loop → property of the current item
+            b.DeclareScalar(new TemplatePath("Price", []) { LeadingDotCount = 1 });
+            b.CloseScope();
+            var schema = b.Build();
+
+            Assert.That(schema.Roots["items"].ItemSchema.Properties["Price"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void LeadingDoubleDot_SkipsOneScope()
+        {
+            var b = new SchemaBuilder();
+            var outerItem = b.DeclareCollection("orders");
+            b.OpenItemScope("orders", outerItem);
+            var innerItem = b.DeclareCollection("orders.lines");
+            b.OpenItemScope("orders.lines", innerItem);
+            // `..Customer` from inner loop = one level up = orders item
+            b.DeclareScalar(new TemplatePath("Customer", []) { LeadingDotCount = 2 });
+            b.CloseScope();
+            b.CloseScope();
+            var schema = b.Build();
+
+            Assert.That(schema.Roots["orders"].ItemSchema.Properties.Keys, Does.Contain("Customer"));
+        }
+
+        [Test]
+        public void LoopIndexAndLengthAreIgnored()
+        {
+            var b = new SchemaBuilder();
+            var item = b.DeclareCollection("items");
+            b.OpenItemScope("items", item);
+            b.DeclareScalar("items._Idx");
+            b.DeclareScalar("items._Length");
+            b.CloseScope();
+            var schema = b.Build();
+
+            Assert.That(schema.Roots["items"].ItemSchema.Properties, Is.Empty);
+        }
+
+        [Test]
+        public void DeclarePath_IndexerPromotesToCollection()
+        {
+            // items[0].Name -> items becomes a Collection whose ItemSchema has the Name property
+            var b = new SchemaBuilder();
+            var path = new TemplatePath("items",
+            [
+                new PathSegment { Kind = PathSegmentKind.Index },
+                new PathSegment { Kind = PathSegmentKind.Member, Name = "Name" }
+            ]);
+            b.DeclareScalar(path);
+            var schema = b.Build();
+
+            var items = schema.Roots["items"];
+            Assert.That(items.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(items.ItemSchema.Properties["Name"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void DeclarePath_MethodCallDropsSubsequentSegments()
+        {
+            // customer.Name.ToUpper() -> ToUpper is a method call, not a property; subsequent paths from
+            // the method's return value are unknown and should not appear in the schema.
+            var b = new SchemaBuilder();
+            var path = new TemplatePath("customer",
+            [
+                new PathSegment { Kind = PathSegmentKind.Member, Name = "Name" },
+                new PathSegment { Kind = PathSegmentKind.Method, Name = "ToUpper" }
+            ]);
+            b.DeclareScalar(path);
+            var schema = b.Build();
+
+            var customer = schema.Roots["customer"];
+            Assert.That(customer.Properties.Keys, Is.EquivalentTo(["Name"]));
+            Assert.That(customer.Properties["Name"].Properties, Is.Empty, "method name should not appear as a property");
+        }
+
+        [Test]
+        public void DottedCollectionWithLeadingDotInsideOuterLoop()
+        {
+            // Loop A on `outer`, inside it loop B on `.inner` (a property of the outer item).
+            // We need to declare the collection at the outer item's schema.
+            var b = new SchemaBuilder();
+            var outerItem = b.DeclareCollection("outer");
+            b.OpenItemScope("outer", outerItem);
+            // Inside the outer loop, declare a collection called `.inner`
+            var innerItem = b.DeclareCollection(".inner");
+            b.OpenItemScope("outer.inner", innerItem); // analyzer reconstructs the absolute key
+            b.DeclareScalar(new TemplatePath("Name", []) { LeadingDotCount = 1 });
+            b.CloseScope();
+            b.CloseScope();
+            var schema = b.Build();
+
+            var outerNode = schema.Roots["outer"];
+            Assert.That(outerNode.ItemSchema.Properties.Keys, Does.Contain("inner"));
+            var inner = outerNode.ItemSchema.Properties["inner"];
+            Assert.That(inner.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(inner.ItemSchema.Properties["Name"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+    }
+}

--- a/DocxTemplater.Test/SchemaExpressionParserTest.cs
+++ b/DocxTemplater.Test/SchemaExpressionParserTest.cs
@@ -1,0 +1,158 @@
+using DocxTemplater.Schema;
+
+namespace DocxTemplater.Test
+{
+    [TestFixture]
+    internal sealed class SchemaExpressionParserTest
+    {
+        private static List<TemplatePath> Collect(string expression)
+        {
+            var paths = new List<TemplatePath>();
+            SchemaExpressionParser.Extract(expression, paths.Add);
+            return paths;
+        }
+
+        [Test]
+        public void SimpleMemberChain()
+        {
+            var paths = Collect("customer.Name");
+            Assert.That(paths, Has.Count.EqualTo(1));
+            Assert.That(paths[0].Root, Is.EqualTo("customer"));
+            Assert.That(paths[0].Segments.Select(s => s.Name), Is.EqualTo(["Name"]));
+        }
+
+        [Test]
+        public void NestedMemberChain()
+        {
+            var paths = Collect("customer.Address.City");
+            Assert.That(paths, Has.Count.EqualTo(1));
+            Assert.That(paths[0].Root, Is.EqualTo("customer"));
+            Assert.That(paths[0].Segments.Select(s => s.Name), Is.EqualTo(["Address", "City"]));
+        }
+
+        [Test]
+        public void TwoIndependentChains()
+        {
+            var paths = Collect("customer.Name + items.Count");
+            Assert.That(paths.Select(p => p.ToString()), Is.EquivalentTo(["customer.Name", "items.Count"]));
+        }
+
+        [Test]
+        public void BooleanShortCircuitDoesNotHideSecondOperand()
+        {
+            var paths = Collect("customer.IsPremium && customer.Score > 5");
+            Assert.That(paths.Select(p => p.ToString()), Is.EquivalentTo(["customer.IsPremium", "customer.Score"]));
+        }
+
+        [Test]
+        public void IndexerWithConstant()
+        {
+            var paths = Collect("items[0].Name");
+            Assert.That(paths, Has.Count.EqualTo(1));
+            Assert.That(paths[0].Root, Is.EqualTo("items"));
+            Assert.That(paths[0].Segments.Select(s => s.Kind), Is.EqualTo([PathSegmentKind.Index, PathSegmentKind.Member]));
+            Assert.That(paths[0].Segments[1].Name, Is.EqualTo("Name"));
+        }
+
+        [Test]
+        public void MethodCall()
+        {
+            var paths = Collect("customer.Name.ToUpper()");
+            Assert.That(paths, Has.Count.EqualTo(1));
+            Assert.That(paths[0].Segments.Select(s => s.Kind), Is.EqualTo([PathSegmentKind.Member, PathSegmentKind.Method]));
+            Assert.That(paths[0].Segments.Select(s => s.Name), Is.EqualTo(["Name", "ToUpper"]));
+        }
+
+        [Test]
+        public void IndexerWithComputedArgumentDiscoversNestedChain()
+        {
+            // items[customer.idx].Name -> two roots
+            var paths = Collect("items[customer.Idx].Name");
+            var asStrings = paths.Select(p => p.ToString()).OrderBy(s => s).ToList();
+            Assert.That(asStrings, Is.EqualTo(["customer.Idx", "items[].Name"]));
+        }
+
+        [Test]
+        public void LeadingDot_ResolvesToParentScope()
+        {
+            // single dot = parent scope; customer is implicit
+            var paths = Collect(".Name");
+            Assert.That(paths, Has.Count.EqualTo(1));
+            Assert.That(paths[0].LeadingDotCount, Is.EqualTo(1));
+            Assert.That(paths[0].Root, Is.EqualTo("Name"));
+            Assert.That(paths[0].Segments, Is.Empty);
+        }
+
+        [Test]
+        public void LeadingDot_WithFurtherMembers()
+        {
+            var paths = Collect(".Address.City");
+            Assert.That(paths, Has.Count.EqualTo(1));
+            Assert.That(paths[0].LeadingDotCount, Is.EqualTo(1));
+            Assert.That(paths[0].Root, Is.EqualTo("Address"));
+            Assert.That(paths[0].Segments.Select(s => s.Name), Is.EqualTo(["City"]));
+        }
+
+        [Test]
+        public void StringLiteralsAreIgnored()
+        {
+            var paths = Collect("customer.Name == \"items.Count\"");
+            Assert.That(paths.Select(p => p.ToString()), Is.EquivalentTo(["customer.Name"]));
+        }
+
+        [Test]
+        public void NumericLiteralsAreIgnored()
+        {
+            var paths = Collect("customer.Score > 5.5");
+            Assert.That(paths.Select(p => p.ToString()), Is.EquivalentTo(["customer.Score"]));
+        }
+
+        [Test]
+        public void EmptyExpression()
+        {
+            var paths = Collect("");
+            Assert.That(paths, Is.Empty);
+        }
+
+        [Test]
+        public void ExpressionWithOuterParens_TrailingToString_StaticallyResolved()
+        {
+            // (foo.bar.ToString()) - DynamicExpresso knows ToString() statically on `object`, so the
+            // call becomes a regular MethodCallExpression (not a CallSite). The inner foo.bar is still
+            // a CallSite chain and gets emitted. ToString does not appear in the schema (it's a
+            // built-in, not a model property) - which is the correct outcome.
+            var paths = Collect("(foo.bar.ToString())");
+            Assert.That(paths.Select(p => p.ToString()), Is.EquivalentTo(["foo.bar"]));
+        }
+
+        // Tripwire tests for the DynamicExpresso internal binder shape. The collector reads
+        // private fields and identifies binders by class name; a library upgrade that changes
+        // either will silently lose paths unless these tests fail loudly.
+        [Test]
+        public void DynamicExpressoBinder_GetMember_StillReadable()
+        {
+            var paths = Collect("customer.Foo.Bar");
+            Assert.That(paths, Has.Count.EqualTo(1), "TemplatePathCollector lost coupling to LateGetMemberCallSiteBinder");
+            Assert.That(paths[0].Segments.Select(s => s.Name), Is.EqualTo(["Foo", "Bar"]));
+        }
+
+        [Test]
+        public void DynamicExpressoBinder_InvokeMethod_StillReadable()
+        {
+            var paths = Collect("customer.DoSomething()");
+            Assert.That(paths, Has.Count.EqualTo(1), "TemplatePathCollector lost coupling to LateInvokeMethodCallSiteBinder");
+            Assert.That(paths[0].Segments, Has.Count.EqualTo(1));
+            Assert.That(paths[0].Segments[0].Kind, Is.EqualTo(PathSegmentKind.Method));
+            Assert.That(paths[0].Segments[0].Name, Is.EqualTo("DoSomething"));
+        }
+
+        [Test]
+        public void DynamicExpressoBinder_GetIndex_StillReadable()
+        {
+            var paths = Collect("items[0]");
+            Assert.That(paths, Has.Count.EqualTo(1), "TemplatePathCollector lost coupling to LateGetIndexCallSiteBinder");
+            Assert.That(paths[0].Segments, Has.Count.EqualTo(1));
+            Assert.That(paths[0].Segments[0].Kind, Is.EqualTo(PathSegmentKind.Index));
+        }
+    }
+}

--- a/DocxTemplater.Test/TemplateSchemaTest.cs
+++ b/DocxTemplater.Test/TemplateSchemaTest.cs
@@ -1,0 +1,200 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocxTemplater.Schema;
+
+namespace DocxTemplater.Test
+{
+    [TestFixture]
+    internal sealed class TemplateSchemaTest
+    {
+        private static DocxTemplate BuildTemplate(string body)
+        {
+            var stream = new MemoryStream();
+            using (var wp = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var main = wp.AddMainDocumentPart();
+                main.Document = new Document(new Body(new Paragraph(new Run(new Text(body)))));
+                wp.Save();
+            }
+            stream.Position = 0;
+            return new DocxTemplate(stream);
+        }
+
+        [Test]
+        public void SimpleVariable()
+        {
+            using var t = BuildTemplate("Hello {{customer.Name}}!");
+            var schema = t.GetTemplateSchema();
+
+            Assert.That(schema.Roots.Keys, Is.EquivalentTo(["customer"]));
+            Assert.That(schema.Roots["customer"].Properties["Name"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void Loop_ProducesCollectionWithItemSchema()
+        {
+            using var t = BuildTemplate("{{#items}}{{items.Price}}{{/items}}");
+            var schema = t.GetTemplateSchema();
+
+            var items = schema.Roots["items"];
+            Assert.That(items.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(items.ItemSchema.Properties["Price"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void Loop_ReferencingOuterModel()
+        {
+            using var t = BuildTemplate("{{#items}}{{items.Price}} for {{customer.Name}}{{/items}}");
+            var schema = t.GetTemplateSchema();
+
+            Assert.That(schema.Roots.Keys, Is.EquivalentTo(["items", "customer"]));
+            Assert.That(schema.Roots["items"].ItemSchema.Properties["Price"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+            Assert.That(schema.Roots["customer"].Properties["Name"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void NestedLoop_DottedScopeKey()
+        {
+            using var t = BuildTemplate("{{#customer.orders}}{{customer.orders.amount}}{{/customer.orders}}");
+            var schema = t.GetTemplateSchema();
+
+            var customer = schema.Roots["customer"];
+            var orders = customer.Properties["orders"];
+            Assert.That(orders.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(orders.ItemSchema.Properties["amount"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void NestedLoopWithLeadingDot()
+        {
+            using var t = BuildTemplate("{{#orders}}{{#.lines}}{{.qty}}{{/.lines}}{{/orders}}");
+            var schema = t.GetTemplateSchema();
+
+            var orders = schema.Roots["orders"];
+            Assert.That(orders.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            var lines = orders.ItemSchema.Properties["lines"];
+            Assert.That(lines.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(lines.ItemSchema.Properties["qty"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void Condition_BothBranchesContributeToSchema()
+        {
+            using var t = BuildTemplate("{?{customer.IsPremium}}{{customer.PremiumLevel}}{{else}}{{customer.StandardLevel}}{{/}}");
+            var schema = t.GetTemplateSchema();
+
+            var customer = schema.Roots["customer"];
+            Assert.That(customer.Properties.Keys, Is.EquivalentTo(["IsPremium", "PremiumLevel", "StandardLevel"]));
+        }
+
+        [Test]
+        public void ConditionExpression_CollectsMemberPaths()
+        {
+            using var t = BuildTemplate("{?{customer.IsPremium && customer.Score > 5}}yes{{/}}");
+            var schema = t.GetTemplateSchema();
+
+            var customer = schema.Roots["customer"];
+            Assert.That(customer.Properties.Keys, Is.EquivalentTo(["IsPremium", "Score"]));
+        }
+
+        [Test]
+        public void ExpressionBlock_CollectsVariables()
+        {
+            using var t = BuildTemplate("Total: {{(items.Count * customer.Multiplier)}}");
+            var schema = t.GetTemplateSchema();
+
+            Assert.That(schema.Roots["items"].Properties.Keys, Does.Contain("Count"));
+            Assert.That(schema.Roots["customer"].Properties.Keys, Does.Contain("Multiplier"));
+        }
+
+        [Test]
+        public void Switch_DeclaresSwitchVariable()
+        {
+            using var t = BuildTemplate("{{#switch:customer.Tier}}{{#case:1}}A{{/}}{{#case:2}}B{{/}}{{/}}");
+            var schema = t.GetTemplateSchema();
+
+            var customer = schema.Roots["customer"];
+            Assert.That(customer.Properties.Keys, Does.Contain("Tier"));
+        }
+
+        [Test]
+        public void IndexerInExpression_PromotesToCollection()
+        {
+            using var t = BuildTemplate("{{(items[0].Name)}}");
+            var schema = t.GetTemplateSchema();
+
+            var items = schema.Roots["items"];
+            Assert.That(items.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(items.ItemSchema.Properties["Name"].Kind, Is.EqualTo(TemplateNodeKind.Scalar));
+        }
+
+        [Test]
+        public void MethodCallDoesNotLeakAsProperty()
+        {
+            using var t = BuildTemplate("{{(customer.Name.ToUpper())}}");
+            var schema = t.GetTemplateSchema();
+
+            var customer = schema.Roots["customer"];
+            Assert.That(customer.Properties.Keys, Is.EquivalentTo(["Name"]));
+            Assert.That(customer.Properties["Name"].Properties, Is.Empty);
+        }
+
+        [Test]
+        public void LoopIndexAndLengthAreFiltered()
+        {
+            using var t = BuildTemplate("{{#items}}{{items._Idx}}/{{items._Length}}{{/items}}");
+            var schema = t.GetTemplateSchema();
+
+            var items = schema.Roots["items"];
+            // _Idx and _Length are loop-internal — schema should not require them
+            Assert.That(items.ItemSchema.Properties.Keys, Does.Not.Contain("_Idx"));
+            Assert.That(items.ItemSchema.Properties.Keys, Does.Not.Contain("_Length"));
+        }
+
+        [Test]
+        public void IgnoredContent_IsNotIncluded()
+        {
+            using var t = BuildTemplate("{{customer.Name}}{{:ignore}}{{secret.ApiKey}}{{/:ignore}}");
+            var schema = t.GetTemplateSchema();
+
+            Assert.That(schema.Roots.Keys, Is.EquivalentTo(["customer"]));
+        }
+
+        [Test]
+        public void EmptyTemplate_YieldsEmptySchema()
+        {
+            using var t = BuildTemplate("Just some static text.");
+            var schema = t.GetTemplateSchema();
+
+            Assert.That(schema.Roots, Is.Empty);
+        }
+
+        [Test]
+        public void Schema_CombinedFeatures()
+        {
+            // A realistic template that exercises loops, nested loops, conditions, expressions and
+            // an outer-model reference, all in one go.
+            using var t = BuildTemplate(
+                "Hello {{customer.Name}} "
+                + "{?{customer.IsPremium}}Premium since {{customer.JoinedAt}}{{/}}"
+                + "{{#customer.orders}}"
+                + "Order {{customer.orders.Id}}: total {{(customer.orders.Total)}}"
+                + "{{#.lines}}{{.Product}} x {{.Qty}}{{/.lines}}"
+                + "{{/customer.orders}}");
+            var schema = t.GetTemplateSchema();
+
+            Assert.That(schema.Roots.Keys, Is.EquivalentTo(["customer"]));
+            var customer = schema.Roots["customer"];
+            Assert.That(customer.Properties.Keys, Is.EquivalentTo(["Name", "IsPremium", "JoinedAt", "orders"]));
+
+            var orders = customer.Properties["orders"];
+            Assert.That(orders.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(orders.ItemSchema.Properties.Keys, Is.EquivalentTo(["Id", "Total", "lines"]));
+
+            var lines = orders.ItemSchema.Properties["lines"];
+            Assert.That(lines.Kind, Is.EqualTo(TemplateNodeKind.Collection));
+            Assert.That(lines.ItemSchema.Properties.Keys, Is.EquivalentTo(["Product", "Qty"]));
+        }
+    }
+}

--- a/DocxTemplater/Blocks/CaseBlock.cs
+++ b/DocxTemplater/Blocks/CaseBlock.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Globalization;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocxTemplater.Schema;
 
 namespace DocxTemplater.Blocks
 {
@@ -48,6 +50,30 @@ namespace DocxTemplater.Blocks
             {
                 base.Expand(models, parentNode);
             }
+        }
+
+        public override void CollectSchema(SchemaBuilder builder)
+        {
+            // The match expression of a non-default case can reference paths (rare, but allowed).
+            // Literals (quoted strings, numbers) contribute nothing - skip the parse in that case.
+            if (!IsDefault && !string.IsNullOrEmpty(MatchExpression) && !IsLiteral(MatchExpression))
+            {
+                SchemaExpressionParser.Extract(MatchExpression, builder.DeclareScalar);
+            }
+            base.CollectSchema(builder);
+        }
+
+        private static bool IsLiteral(string s)
+        {
+            if (s.Length == 0)
+            {
+                return true;
+            }
+            if (s[0] is '\'' or '"')
+            {
+                return true;
+            }
+            return double.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out _);
         }
 
         private bool IsNestedUnderSwitch()

--- a/DocxTemplater/Blocks/ConditionalBlock.cs
+++ b/DocxTemplater/Blocks/ConditionalBlock.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocxTemplater.Schema;
 
 namespace DocxTemplater.Blocks
 {
@@ -48,6 +49,14 @@ namespace DocxTemplater.Blocks
         public override string ToString()
         {
             return $"ConditionalBlock: {m_condition}";
+        }
+
+        public override void CollectSchema(SchemaBuilder builder)
+        {
+            // Extract identifiers used by the condition itself, then recurse into both branches
+            // (if-body and optional else-body) so paths only reachable on one side still appear in the schema.
+            SchemaExpressionParser.Extract(m_condition, builder.DeclareScalar);
+            base.CollectSchema(builder);
         }
     }
 }

--- a/DocxTemplater/Blocks/ContentBlock.cs
+++ b/DocxTemplater/Blocks/ContentBlock.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocxTemplater.Schema;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -100,6 +101,61 @@ namespace DocxTemplater.Blocks
             InsertContentAndReplaceVariables(models, parentNode);
             ExpandChildBlocks(models, parentNode);
             RemoveChildBlockInsertionPoints(parentNode);
+        }
+
+        /// <summary>
+        /// Adds the model paths referenced by this block (and its children) to the schema being built.
+        /// Base implementation declares the variables/expressions in this block's immediate content and
+        /// recurses into child blocks. Subclasses override to add their own contribution
+        /// (loop-collection, condition expression, switch selector, etc.) before/after the base call.
+        /// </summary>
+        public virtual void CollectSchema(SchemaBuilder builder)
+        {
+            CollectMarkedVariables(m_content, builder);
+            foreach (var child in m_childBlocks)
+            {
+                child.CollectSchema(builder);
+            }
+        }
+
+        /// <summary>
+        /// Scans the given OpenXml elements for marked Text nodes (Variable / Expression patterns)
+        /// and declares their paths in the schema. Uses the same marker-lookup as
+        /// <see cref="Formatter.VariableReplacer"/>; the text content holds the original
+        /// <c>{{...}}</c> pattern after the run-merge pass, so we recover the match without
+        /// walking the document tree manually.
+        /// </summary>
+        internal static void CollectMarkedVariables(IEnumerable<OpenXmlElement> elements, SchemaBuilder builder)
+        {
+            if (elements == null)
+            {
+                return;
+            }
+            foreach (var element in elements)
+            {
+                var marked = element.GetElementsWithMarker(PatternType.Variable)
+                    .Concat(element.GetElementsWithMarker(PatternType.Expression))
+                    .OfType<Text>();
+                foreach (var text in marked)
+                {
+                    var match = PatternMatcher.FindSyntaxPatterns(text.Text).FirstOrDefault();
+                    if (match == null)
+                    {
+                        continue;
+                    }
+                    if (match.Type == PatternType.Variable)
+                    {
+                        builder.DeclareScalar(match.Variable);
+                    }
+                    else if (match.Type == PatternType.Expression)
+                    {
+                        // match.Variable for an Expression includes the outer parentheses (e.g. "(x.y)").
+                        // Hand it to the parser as-is - DynamicExpresso treats `(e)` and `e` identically,
+                        // same as VariableReplacer.ReplaceVariables does at render time.
+                        SchemaExpressionParser.Extract(match.Variable, builder.DeclareScalar);
+                    }
+                }
+            }
         }
 
         protected virtual void InsertContentAndReplaceVariables(IModelLookup models, OpenXmlElement parentNode)

--- a/DocxTemplater/Blocks/IgnoreBlock.cs
+++ b/DocxTemplater/Blocks/IgnoreBlock.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocxTemplater.Schema;
 using System.Linq;
 
 namespace DocxTemplater.Blocks
@@ -35,6 +36,11 @@ namespace DocxTemplater.Blocks
         public override string ToString()
         {
             return $"IgnoreBlock";
+        }
+
+        public override void CollectSchema(SchemaBuilder builder)
+        {
+            // Content inside :ignore is dropped at render time; do not contribute to the schema.
         }
     }
 }

--- a/DocxTemplater/Blocks/InlineKeyWordBlock.cs
+++ b/DocxTemplater/Blocks/InlineKeyWordBlock.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocxTemplater.Schema;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -62,6 +63,11 @@ namespace DocxTemplater.Blocks
             };
             res.Add(element);
             m_content = res;
+        }
+
+        public override void CollectSchema(SchemaBuilder builder)
+        {
+            // Inline keywords (page break, section break, ...) carry no model references.
         }
     }
 }

--- a/DocxTemplater/Blocks/LoopBlock.cs
+++ b/DocxTemplater/Blocks/LoopBlock.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Linq;
 using DocumentFormat.OpenXml;
+using DocxTemplater.Schema;
 using Text = DocumentFormat.OpenXml.Wordprocessing.Text;
 
 namespace DocxTemplater.Blocks
@@ -68,6 +69,30 @@ namespace DocxTemplater.Blocks
         public override string ToString()
         {
             return $"LoopBlock: {m_collectionName}";
+        }
+
+        public override void CollectSchema(SchemaBuilder builder)
+        {
+            // m_collectionName can be dot-prefixed (e.g. `.subitems` for a nested loop on the outer item).
+            // The SchemaBuilder needs the absolute key against the current scope stack to register the item scope.
+            var absoluteKey = builder.ResolveAbsoluteScopeKey(m_collectionName);
+            var itemSchema = builder.DeclareCollection(m_collectionName);
+            if (itemSchema != null)
+            {
+                builder.OpenItemScope(absoluteKey, itemSchema);
+            }
+            else
+            {
+                builder.OpenTransparentScope();
+            }
+            try
+            {
+                base.CollectSchema(builder);
+            }
+            finally
+            {
+                builder.CloseScope();
+            }
         }
     }
 }

--- a/DocxTemplater/Blocks/RangeLoopBlock.cs
+++ b/DocxTemplater/Blocks/RangeLoopBlock.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
+using System.Globalization;
 using System.Linq;
 using DocumentFormat.OpenXml;
+using DocxTemplater.Schema;
 using Text = DocumentFormat.OpenXml.Wordprocessing.Text;
 
 namespace DocxTemplater.Blocks
@@ -115,6 +117,25 @@ namespace DocxTemplater.Blocks
         public override string ToString()
         {
             return $"RangeLoopBlock: {m_indexName}:{m_countVariable}";
+        }
+
+        public override void CollectSchema(SchemaBuilder builder)
+        {
+            // The count side can be either an int literal or a path on the model; only declare paths.
+            if (!int.TryParse(m_countVariable, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            {
+                SchemaExpressionParser.Extract(m_countVariable, builder.DeclareScalar);
+            }
+            // Range loops introduce a scope level for dot-resolution but no named item.
+            builder.OpenTransparentScope();
+            try
+            {
+                base.CollectSchema(builder);
+            }
+            finally
+            {
+                builder.CloseScope();
+            }
         }
     }
 }

--- a/DocxTemplater/Blocks/SwitchBlock.cs
+++ b/DocxTemplater/Blocks/SwitchBlock.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocxTemplater.Schema;
 
 namespace DocxTemplater.Blocks
 {
@@ -82,6 +83,12 @@ namespace DocxTemplater.Blocks
         public override string ToString()
         {
             return $"SwitchBlock: {m_switchVariable}";
+        }
+
+        public override void CollectSchema(SchemaBuilder builder)
+        {
+            SchemaExpressionParser.Extract(m_switchVariable, builder.DeclareScalar);
+            base.CollectSchema(builder);
         }
     }
 }

--- a/DocxTemplater/DocxTemplate.cs
+++ b/DocxTemplater/DocxTemplate.cs
@@ -1,8 +1,11 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
+using DocxTemplater.Blocks;
 using DocxTemplater.Formatter;
+using DocxTemplater.Schema;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using DocxTemplater.Extensions.Charts;
@@ -13,6 +16,11 @@ namespace DocxTemplater
     {
         private readonly Stream m_stream;
         private readonly WordprocessingDocument m_wpDocument;
+
+        // Block trees built by GetTemplateSchema, keyed by the node they were built from (header /
+        // root / footer). Process reuses these instead of rebuilding the (now mutated) tree.
+        private readonly Dictionary<OpenXmlCompositeElement, IReadOnlyCollection<ContentBlock>> m_prebuiltBlocks = new();
+        private TemplateSchema m_schema;
 
         private static readonly FileFormatVersions TargetMinimumVersion = FileFormatVersions.Office2010;
 
@@ -106,12 +114,12 @@ namespace DocxTemplater
             Processed = true;
             foreach (var header in m_wpDocument.MainDocumentPart.HeaderParts.ToList())
             {
-                ProcessNode(header.Header);
+                RenderOrProcessNode(header.Header);
             }
-            ProcessNode(m_wpDocument.MainDocumentPart.RootElement);
+            RenderOrProcessNode(m_wpDocument.MainDocumentPart.RootElement);
             foreach (var footer in m_wpDocument.MainDocumentPart.FooterParts.ToList())
             {
-                ProcessNode(footer.Footer);
+                RenderOrProcessNode(footer.Footer);
             }
             Context.VariableReplacer.WriteErrorMessages(m_wpDocument.MainDocumentPart.RootElement);
             m_wpDocument.Save();
@@ -119,6 +127,86 @@ namespace DocxTemplater
             return m_stream;
         }
 
+        private void RenderOrProcessNode(OpenXmlCompositeElement node)
+        {
+            if (node == null)
+            {
+                return;
+            }
+            // If GetTemplateSchema already built the block tree for this node, render from it instead
+            // of rebuilding (the tree was extracted from the node, so a rebuild would find nothing /
+            // corrupt the document). Otherwise run the full pipeline as usual.
+            if (m_prebuiltBlocks.TryGetValue(node, out var blocks))
+            {
+                RenderNode(node, blocks);
+            }
+            else
+            {
+                ProcessNode(node);
+            }
+        }
+
+
+        /// <summary>
+        /// Statically analyzes the template (without rendering it) and returns the structural schema
+        /// of the variables, collections, and nested objects the template references. Use this to
+        /// validate a caller's model against the template's expectations before rendering, or to
+        /// generate a skeleton object for callers to fill in.
+        /// </summary>
+        /// <remarks>
+        /// This method builds the internal block tree (mutates the XML) but does not render. The
+        /// built tree is cached, so a subsequent call to <see cref="Process"/> renders from it
+        /// instead of rebuilding; calling <c>GetTemplateSchema</c> and then <c>Process</c> on the same
+        /// instance is supported (and the result is itself cached, so repeated calls are cheap).
+        /// It must be called before <see cref="Process"/>, not after. The schema represents the union
+        /// of all branches (both <c>if</c> and <c>else</c>, all <c>case</c>s, every loop body) -
+        /// callers must be prepared to bind anything the template could reach at runtime.
+        /// See <see cref="TemplateSchema"/> for known limitations.
+        /// </remarks>
+        public TemplateSchema GetTemplateSchema()
+        {
+            if (m_schema != null)
+            {
+                return m_schema;
+            }
+            if (Processed)
+            {
+                throw new OpenXmlTemplateException($"{nameof(GetTemplateSchema)} must be called before {nameof(Process)}.");
+            }
+            var builder = new SchemaBuilder();
+            if (m_wpDocument.MainDocumentPart != null)
+            {
+                foreach (var header in m_wpDocument.MainDocumentPart.HeaderParts.ToList())
+                {
+                    CollectFromPart(builder, header.Header);
+                }
+                CollectFromPart(builder, m_wpDocument.MainDocumentPart.RootElement);
+                foreach (var footer in m_wpDocument.MainDocumentPart.FooterParts.ToList())
+                {
+                    CollectFromPart(builder, footer.Footer);
+                }
+            }
+            m_schema = builder.Build();
+            return m_schema;
+        }
+
+        private void CollectFromPart(SchemaBuilder builder, OpenXmlCompositeElement rootElement)
+        {
+            if (rootElement == null)
+            {
+                return;
+            }
+            var rootBlocks = BuildBlockTree(rootElement);
+            // Cache the built tree so Process renders from it instead of rebuilding the mutated node.
+            m_prebuiltBlocks[rootElement] = rootBlocks;
+            // Root-level variables outside any block remain as marked Text nodes in the rootElement
+            // after the block-tree pipeline extracts each block's content. Pick those up directly.
+            ContentBlock.CollectMarkedVariables([rootElement], builder);
+            foreach (var block in rootBlocks)
+            {
+                block.CollectSchema(builder);
+            }
+        }
 
         public void Dispose()
         {

--- a/DocxTemplater/Schema/SchemaBuilder.cs
+++ b/DocxTemplater/Schema/SchemaBuilder.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+
+namespace DocxTemplater.Schema
+{
+    /// <summary>
+    /// Builds a <see cref="TemplateSchema"/> from a stream of path declarations emitted by
+    /// the template analyzer. Mirrors the runtime resolution semantics of
+    /// <see cref="DocxTemplater.ModelLookup"/>: paths whose first segment matches a loop's
+    /// collection name resolve into that loop's item schema; otherwise they fall through to
+    /// the next outer scope and ultimately the root.
+    /// </summary>
+    internal sealed class SchemaBuilder
+    {
+        private sealed class Frame
+        {
+            /// <summary>For loop scopes: dotted collection path (e.g. "items" or "customer.orders").</summary>
+            public string ScopeKey { get; init; }
+
+            /// <summary>For loop scopes: schema for an element of the collection. Paths resolved here are added below this node.</summary>
+            public TemplateSchemaNode ItemSchema { get; init; }
+
+            /// <summary>True for the root frame and for non-binding scopes (e.g. range loops).</summary>
+            public bool IsRoot => ScopeKey == null;
+        }
+
+        private readonly Dictionary<string, TemplateSchemaNode> m_roots = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Stack<Frame> m_frames = new();
+
+        public SchemaBuilder()
+        {
+            m_frames.Push(new Frame());
+        }
+
+        /// <summary>
+        /// Declares <paramref name="collectionPath"/> as a collection in the appropriate scope and
+        /// returns the schema node for an element of it (so the caller can open an item scope).
+        /// </summary>
+        public TemplateSchemaNode DeclareCollection(string collectionPath)
+        {
+            var path = ParseDottedPath(collectionPath);
+            var node = ResolveAndDeclareLeaf(path, asCollection: true);
+            return node?.EnsureItemSchema();
+        }
+
+        /// <summary>Declares a scalar path (the leaf becomes a <see cref="TemplateNodeKind.Scalar"/>).</summary>
+        public void DeclareScalar(string dottedPath)
+        {
+            DeclareScalar(ParseDottedPath(dottedPath));
+        }
+
+        public void DeclareScalar(TemplatePath path)
+        {
+            ResolveAndDeclareLeaf(path, asCollection: false);
+        }
+
+        /// <summary>
+        /// Pushes a loop scope. <paramref name="scopeKey"/> is the dotted collection path
+        /// (matches <see cref="DocxTemplater.ModelLookup"/>'s scope-key convention).
+        /// </summary>
+        public void OpenItemScope(string scopeKey, TemplateSchemaNode itemSchema)
+        {
+            m_frames.Push(new Frame { ScopeKey = scopeKey, ItemSchema = itemSchema });
+        }
+
+        /// <summary>Pushes a transparent scope (e.g. a range loop) that introduces a scope level but no item schema.</summary>
+        public void OpenTransparentScope()
+        {
+            m_frames.Push(new Frame { ScopeKey = "", ItemSchema = null });
+        }
+
+        public void CloseScope()
+        {
+            if (m_frames.Count <= 1)
+            {
+                throw new InvalidOperationException("Cannot close root scope");
+            }
+            m_frames.Pop();
+        }
+
+        public TemplateSchema Build()
+        {
+            return new TemplateSchema(m_roots);
+        }
+
+        /// <summary>
+        /// Combines <paramref name="varName"/> (which may start with leading dots) with the enclosing
+        /// scope's absolute key, so the result identifies the scope independent of where it was opened.
+        /// E.g. inside loop on <c>orders</c>, <c>.lines</c> resolves to <c>orders.lines</c>.
+        /// </summary>
+        public string ResolveAbsoluteScopeKey(string varName)
+        {
+            if (string.IsNullOrEmpty(varName))
+            {
+                return string.Empty;
+            }
+            int dots = 0;
+            while (dots < varName.Length && varName[dots] == '.')
+            {
+                dots++;
+            }
+            var rest = dots > 0 ? varName[dots..] : varName;
+            if (dots == 0)
+            {
+                return rest;
+            }
+            // Walk up `dots` scope levels from the current top to find the outer absolute key.
+            var framesArray = m_frames.ToArray(); // index 0 == top (innermost)
+            if (dots - 1 < framesArray.Length)
+            {
+                var outer = framesArray[dots - 1].ScopeKey;
+                if (!string.IsNullOrEmpty(outer))
+                {
+                    return outer + "." + rest;
+                }
+            }
+            return rest;
+        }
+
+        private TemplateSchemaNode ResolveAndDeclareLeaf(TemplatePath path, bool asCollection)
+        {
+            if (path == null || (string.IsNullOrEmpty(path.Root) && path.Segments.Count == 0))
+            {
+                return null;
+            }
+
+            // For scope-key matching we only need the dotted *member* prefix (root + leading member segments
+            // before any indexer/method). Indexer breaks the prefix; method ends the chain.
+            var memberPrefix = BuildMemberPrefix(path);
+
+            TemplateSchemaNode parent;
+            int startSegmentIndex;
+            bool rootConsumed;
+
+            if (path.LeadingDotCount > 0)
+            {
+                var framesArray = m_frames.ToArray();
+                int index = path.LeadingDotCount - 1;
+                if (index < 0 || index >= framesArray.Length)
+                {
+                    return null;
+                }
+                var frame = framesArray[index];
+                if (frame.ItemSchema == null)
+                {
+                    return null;
+                }
+                parent = frame.ItemSchema;
+                startSegmentIndex = 0;
+                rootConsumed = false; // the path's root is a property of the parent scope (no scope key shadows it)
+            }
+            else if (TryMatchScopeFrame(memberPrefix, out parent, out var matchedCount))
+            {
+                // matchedCount counts entries from memberPrefix that the scope key consumed. memberPrefix[0] == path.Root.
+                rootConsumed = matchedCount >= 1;
+                startSegmentIndex = matchedCount - 1; // segment index 0 == path.Segments[0]
+                if (startSegmentIndex < 0)
+                {
+                    startSegmentIndex = 0;
+                }
+            }
+            else
+            {
+                parent = GetOrAddRoot(path.Root);
+                rootConsumed = true;
+                startSegmentIndex = 0;
+            }
+
+            return Walk(parent, path, startSegmentIndex, rootConsumed, asCollection);
+        }
+
+        /// <summary>Member prefix used for scope-key matching: root + member segments up to (but not including) the first non-member step.</summary>
+        private static List<string> BuildMemberPrefix(TemplatePath path)
+        {
+            var prefix = new List<string>(1 + path.Segments.Count);
+            if (!string.IsNullOrEmpty(path.Root))
+            {
+                prefix.Add(path.Root);
+            }
+            foreach (var s in path.Segments)
+            {
+                if (s.Kind != PathSegmentKind.Member)
+                {
+                    break;
+                }
+                prefix.Add(s.Name);
+            }
+            return prefix;
+        }
+
+        /// <summary>
+        /// Walks a path's segments from the resolved scope target, applying the right schema operation per segment kind:
+        /// Member → descend into a property; Index → promote to Collection and descend into ItemSchema; Method → terminate.
+        /// </summary>
+        private static TemplateSchemaNode Walk(TemplateSchemaNode parent, TemplatePath path, int startSegmentIndex, bool rootConsumed, bool asCollection)
+        {
+            if (parent == null)
+            {
+                return null;
+            }
+
+            var current = parent;
+
+            // If the root wasn't consumed by a scope match, treat it as a Member step from `parent`.
+            if (!rootConsumed && !string.IsNullOrEmpty(path.Root))
+            {
+                if (IsLoopLocal(path.Root))
+                {
+                    return null;
+                }
+                current = current.GetOrAddProperty(path.Root);
+            }
+
+            for (int i = startSegmentIndex; i < path.Segments.Count; i++)
+            {
+                var seg = path.Segments[i];
+                bool isLast = i == path.Segments.Count - 1;
+
+                if (seg.Kind == PathSegmentKind.Method)
+                {
+                    // Method invocation returns a value of unknown shape. Anything after is dropped.
+                    return null;
+                }
+                if (seg.Kind == PathSegmentKind.Index)
+                {
+                    current.PromoteToCollection();
+                    current = current.EnsureItemSchema();
+                    continue;
+                }
+                // Member
+                if (IsLoopLocal(seg.Name))
+                {
+                    return null;
+                }
+                current = current.GetOrAddProperty(seg.Name);
+                if (isLast && asCollection)
+                {
+                    current.PromoteToCollection();
+                }
+            }
+            return current;
+        }
+
+        private bool TryMatchScopeFrame(List<string> memberPrefix, out TemplateSchemaNode parent, out int matchedCount)
+        {
+            // Iterate frames from top (innermost) to root. First scope-key that is a prefix of `memberPrefix` wins.
+            foreach (var frame in m_frames)
+            {
+                if (frame.IsRoot || string.IsNullOrEmpty(frame.ScopeKey) || frame.ItemSchema == null)
+                {
+                    continue;
+                }
+                var keyParts = frame.ScopeKey.Split('.');
+                if (keyParts.Length > memberPrefix.Count)
+                {
+                    continue;
+                }
+                bool match = true;
+                for (int i = 0; i < keyParts.Length; i++)
+                {
+                    if (!string.Equals(keyParts[i], memberPrefix[i], StringComparison.OrdinalIgnoreCase))
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match)
+                {
+                    parent = frame.ItemSchema;
+                    matchedCount = keyParts.Length;
+                    return true;
+                }
+            }
+            parent = null;
+            matchedCount = 0;
+            return false;
+        }
+
+        private TemplateSchemaNode GetOrAddRoot(string name)
+        {
+            if (!m_roots.TryGetValue(name, out var node))
+            {
+                node = new TemplateSchemaNode(name, TemplateNodeKind.Object);
+                m_roots[name] = node;
+            }
+            return node;
+        }
+
+        private static TemplatePath ParseDottedPath(string dottedPath)
+        {
+            if (string.IsNullOrEmpty(dottedPath))
+            {
+                return new TemplatePath(string.Empty, Array.Empty<PathSegment>());
+            }
+            int dots = 0;
+            while (dots < dottedPath.Length && dottedPath[dots] == '.')
+            {
+                dots++;
+            }
+            var rest = dots > 0 ? dottedPath[dots..] : dottedPath;
+            var parts = rest.Split('.');
+            if (parts.Length == 0 || parts[0].Length == 0)
+            {
+                return new TemplatePath(string.Empty, Array.Empty<PathSegment>()) { LeadingDotCount = dots };
+            }
+            var segs = new List<PathSegment>(parts.Length - 1);
+            for (int i = 1; i < parts.Length; i++)
+            {
+                segs.Add(new PathSegment { Kind = PathSegmentKind.Member, Name = parts[i] });
+            }
+            return new TemplatePath(parts[0], segs) { LeadingDotCount = dots };
+        }
+
+        private static bool IsLoopLocal(string name)
+        {
+            return name is "_Idx" or "_Length";
+        }
+    }
+}

--- a/DocxTemplater/Schema/SchemaExpressionParser.cs
+++ b/DocxTemplater/Schema/SchemaExpressionParser.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using DynamicExpresso;
+
+namespace DocxTemplater.Schema
+{
+    /// <summary>
+    /// Schema-only parser that recovers member-access paths from DynamicExpresso expressions.
+    /// All the "reach into DynamicExpresso internals" code lives here, isolated from the rest of
+    /// the codebase.
+    /// </summary>
+    /// <remarks>
+    /// DynamicExpresso reduces dynamic dispatch into <see cref="InvocationExpression"/>s that
+    /// invoke <see cref="CallSite"/>.Target. The site's binder identifies the operation
+    /// (LateGetMember / LateGetIndex / LateInvokeMethod) and exposes the member or method name via
+    /// a private field. We identify the binder by class name and read the field by name with
+    /// defensive null-checks, so an upstream rename causes paths to be skipped rather than a crash.
+    /// Tripwire tests in <c>SchemaExpressionParserTest</c> fail loudly on shape changes.
+    /// </remarks>
+    internal static class SchemaExpressionParser
+    {
+
+        // Pre-scan replaces leading dots (relative-scope syntax `.foo`, `..foo`) with synthetic
+        // root identifiers so DynamicExpresso accepts the expression. Mirrors the leading-dot
+        // rewriting in DocxTemplater.ScriptCompiler (which uses RegexWordStartingWithDot for the
+        // same purpose during runtime compilation).
+        private static readonly Regex LeadingDotPattern = new(
+            @"(?:^|(?<unary>[+\-!])|(?<=[^.\p{L}\p{N}_?\]]))(?<dots>\.+)(?<prop>[\p{L}\p{N}_]*)",
+            RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+
+        /// <summary>
+        /// Parses <paramref name="expression"/> and emits a <see cref="TemplatePath"/> for every
+        /// member-access chain. Failures during parse are silent — a broken expression will surface
+        /// as an error at actual render time, not here.
+        /// </summary>
+        public static void Extract(string expression, Action<TemplatePath> onPath)
+        {
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return;
+            }
+
+            var (rewritten, leadingDotsByRoot) = NormalizeLeadingDots(expression);
+
+            Expression body;
+            try
+            {
+                var interpreter = new Interpreter();
+                var identifiers = interpreter.DetectIdentifiers(rewritten);
+                foreach (var unknown in identifiers.UnknownIdentifiers)
+                {
+                    // Bind as ParameterExpression (not a constant value) so the parsed tree carries
+                    // the identifier's name on its root - we attribute paths via that name.
+                    interpreter.SetExpression(unknown, Expression.Parameter(typeof(SchemaPlaceholder), unknown));
+                }
+                body = interpreter.Parse(rewritten).Expression;
+            }
+            catch (Exception)
+            {
+                return;
+            }
+
+            var visitor = new SchemaPathVisitor(leadingDotsByRoot, onPath);
+            visitor.Visit(body);
+        }
+
+        private static (string Cleaned, Dictionary<string, int> LeadingDotsByRoot) NormalizeLeadingDots(string expression)
+        {
+            var dotsByRoot = new Dictionary<string, int>(StringComparer.Ordinal);
+            var rewritten = LeadingDotPattern.Replace(
+                expression,
+                m =>
+                {
+                    var unary = m.Groups["unary"].Value;
+                    var dots = m.Groups["dots"].Value.Length;
+                    var prop = m.Groups["prop"].Value;
+                    if (prop.Length == 0)
+                    {
+                        return m.Value;
+                    }
+                    var synth = "__s" + dots + "_" + prop;
+                    dotsByRoot[synth] = dots;
+                    return unary + synth;
+                });
+            return (rewritten, dotsByRoot);
+        }
+
+        private sealed class SchemaPathVisitor : ExpressionVisitor
+        {
+            private readonly Dictionary<string, int> m_leadingDotsByRoot;
+            private readonly Action<TemplatePath> m_onPath;
+
+            public SchemaPathVisitor(Dictionary<string, int> leadingDotsByRoot, Action<TemplatePath> onPath)
+            {
+                m_leadingDotsByRoot = leadingDotsByRoot;
+                m_onPath = onPath;
+            }
+
+            protected override Expression VisitInvocation(InvocationExpression node)
+            {
+                if (TryConsumeChain(node, out var path, out var subExpressionsToVisit))
+                {
+                    m_onPath(path);
+                    foreach (var sub in subExpressionsToVisit)
+                    {
+                        Visit(sub);
+                    }
+                    return node;
+                }
+                return base.VisitInvocation(node);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                // Standalone parameter reference (body is just `.Name` after dot-rewriting, or `customer`).
+                // Successful chain consumption returns without descending into children, so this fires only
+                // when a parameter is referenced without any subsequent member/index/method access.
+                EmitRootPath(node);
+                return base.VisitParameter(node);
+            }
+
+            private void EmitRootPath(ParameterExpression param)
+            {
+                var rootName = param.Name ?? string.Empty;
+                int dots = 0;
+                if (m_leadingDotsByRoot.TryGetValue(rootName, out var d))
+                {
+                    dots = d;
+                    rootName = StripSyntheticPrefix(rootName);
+                }
+                m_onPath(new TemplatePath(rootName, Array.Empty<PathSegment>()) { LeadingDotCount = dots });
+            }
+
+            private static string StripSyntheticPrefix(string syntheticName)
+            {
+                var underscore = syntheticName.IndexOf('_', 3);
+                return underscore > 0 ? syntheticName[(underscore + 1)..] : syntheticName;
+            }
+
+            private bool TryConsumeChain(InvocationExpression node, out TemplatePath path, out List<Expression> subExpressions)
+            {
+                path = null;
+                subExpressions = new List<Expression>();
+                var segments = new List<PathSegment>();
+
+                Expression current = node;
+                while (current is InvocationExpression invoke && TryDecodeSegment(invoke, out var seg, out var target, out var subs))
+                {
+                    segments.Add(seg);
+                    subExpressions.AddRange(subs);
+                    current = target;
+                }
+
+                if (segments.Count == 0)
+                {
+                    return false;
+                }
+                if (current is not ParameterExpression param)
+                {
+                    return false;
+                }
+
+                segments.Reverse();
+
+                var rootName = param.Name ?? string.Empty;
+                int dots = 0;
+                if (m_leadingDotsByRoot.TryGetValue(rootName, out var d))
+                {
+                    dots = d;
+                    rootName = StripSyntheticPrefix(rootName);
+                }
+
+                path = new TemplatePath(rootName, segments) { LeadingDotCount = dots };
+                return true;
+            }
+
+            private static bool TryDecodeSegment(InvocationExpression invoke, out PathSegment segment, out Expression target, out List<Expression> additionalSubExpressions)
+            {
+                segment = null;
+                target = null;
+                additionalSubExpressions = new List<Expression>();
+
+                if (invoke.Arguments.Count < 2)
+                {
+                    return false;
+                }
+                if (invoke.Arguments[0] is not ConstantExpression callSiteConst)
+                {
+                    return false;
+                }
+                if (callSiteConst.Value is not CallSite site)
+                {
+                    return false;
+                }
+
+                var binderTypeName = site.Binder.GetType().Name;
+                if (binderTypeName == "LateGetMemberCallSiteBinder")
+                {
+                    if (invoke.Arguments.Count != 2)
+                    {
+                        return false;
+                    }
+                    var name = ReadStringField(site.Binder, "_propertyOrFieldName");
+                    if (name == null)
+                    {
+                        return false;
+                    }
+                    segment = new PathSegment { Kind = PathSegmentKind.Member, Name = name };
+                    target = invoke.Arguments[1];
+                    return true;
+                }
+                if (binderTypeName == "LateInvokeMethodCallSiteBinder")
+                {
+                    var name = ReadStringField(site.Binder, "_methodName");
+                    if (name == null)
+                    {
+                        return false;
+                    }
+                    segment = new PathSegment { Kind = PathSegmentKind.Method, Name = name };
+                    target = invoke.Arguments[1];
+                    for (int i = 2; i < invoke.Arguments.Count; i++)
+                    {
+                        additionalSubExpressions.Add(invoke.Arguments[i]);
+                    }
+                    return true;
+                }
+                if (binderTypeName == "LateGetIndexCallSiteBinder")
+                {
+                    if (invoke.Arguments.Count < 3)
+                    {
+                        return false;
+                    }
+                    segment = new PathSegment { Kind = PathSegmentKind.Index };
+                    target = invoke.Arguments[1];
+                    for (int i = 2; i < invoke.Arguments.Count; i++)
+                    {
+                        additionalSubExpressions.Add(invoke.Arguments[i]);
+                    }
+                    return true;
+                }
+                return false;
+            }
+
+            private static string ReadStringField(CallSiteBinder binder, string fieldName)
+            {
+                var f = binder.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+                return f?.GetValue(binder) as string;
+            }
+        }
+    }
+}

--- a/DocxTemplater/Schema/SchemaPlaceholder.cs
+++ b/DocxTemplater/Schema/SchemaPlaceholder.cs
@@ -1,0 +1,32 @@
+using System.Dynamic;
+
+namespace DocxTemplater.Schema
+{
+    /// <summary>
+    /// Tracking placeholder bound to each unknown identifier when the schema extractor parses
+    /// an expression with DynamicExpresso. Being a <see cref="DynamicObject"/> forces
+    /// DynamicExpresso to emit dynamic dispatch — a CallSite-based tree the extractor introspects
+    /// to recover member access paths. The placeholder itself is never executed; only its presence
+    /// at parse time matters.
+    /// </summary>
+    internal sealed class SchemaPlaceholder : DynamicObject
+    {
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            result = new SchemaPlaceholder();
+            return true;
+        }
+
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            result = new SchemaPlaceholder();
+            return true;
+        }
+
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        {
+            result = new SchemaPlaceholder();
+            return true;
+        }
+    }
+}

--- a/DocxTemplater/Schema/TemplateNodeKind.cs
+++ b/DocxTemplater/Schema/TemplateNodeKind.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace DocxTemplater.Schema
+{
+    /// <summary>
+    /// Kind of a node in a <see cref="TemplateSchema"/>.
+    /// </summary>
+    [SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "Schema vocabulary aligns with JSON/template terminology")]
+    public enum TemplateNodeKind
+    {
+        /// <summary>
+        /// A leaf value (string, number, bool, ...). Has no children.
+        /// </summary>
+        Scalar,
+
+        /// <summary>
+        /// A composite value with named properties (<see cref="TemplateSchemaNode.Properties"/>).
+        /// </summary>
+        Object,
+
+        /// <summary>
+        /// A collection. The shape of an element is described by <see cref="TemplateSchemaNode.ItemSchema"/>.
+        /// </summary>
+        Collection
+    }
+}

--- a/DocxTemplater/Schema/TemplatePath.cs
+++ b/DocxTemplater/Schema/TemplatePath.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace DocxTemplater.Schema
+{
+    internal enum PathSegmentKind
+    {
+        /// <summary>Property/field access: <c>x.Foo</c>.</summary>
+        Member,
+
+        /// <summary>Method invocation: <c>x.Foo()</c>. Schema-wise the method is treated like a member (the return value is what's used).</summary>
+        Method,
+
+        /// <summary>Indexed access: <c>x[0]</c> or <c>x["key"]</c>.</summary>
+        Index
+    }
+
+    internal sealed class PathSegment
+    {
+        public PathSegmentKind Kind { get; init; }
+
+        /// <summary>Member or method name. <c>null</c> for indexed access.</summary>
+        public string Name { get; init; }
+    }
+
+    /// <summary>
+    /// A path through the model as referenced by a single expression: root parameter + a chain of accesses.
+    /// </summary>
+    internal sealed class TemplatePath
+    {
+        public TemplatePath(string root, IReadOnlyList<PathSegment> segments)
+        {
+            Root = root;
+            Segments = segments;
+        }
+
+        /// <summary>Root identifier (parameter name). Empty string for paths starting with leading dots (relative scope).</summary>
+        public string Root { get; }
+
+        /// <summary>Number of leading dots in the original source. 0 for absolute paths, &gt;0 for relative-scope paths.</summary>
+        public int LeadingDotCount { get; init; }
+
+        public IReadOnlyList<PathSegment> Segments { get; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append(new string('.', LeadingDotCount));
+            sb.Append(Root);
+            foreach (var s in Segments)
+            {
+                sb.Append(s.Kind switch
+                {
+                    PathSegmentKind.Member => "." + s.Name,
+                    PathSegmentKind.Method => "." + s.Name + "()",
+                    PathSegmentKind.Index => "[]",
+                    _ => "?"
+                });
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/DocxTemplater/Schema/TemplateSchema.cs
+++ b/DocxTemplater/Schema/TemplateSchema.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace DocxTemplater.Schema
+{
+    /// <summary>
+    /// Structural schema of variables referenced by a template — the shape of the model
+    /// a caller has to provide so the template can be rendered without missing-binding errors.
+    /// </summary>
+    /// <remarks>
+    /// The schema is the union over all branches (both <c>if</c> and <c>else</c>, all
+    /// <c>case</c>s, etc.) — a caller has to be prepared to bind everything that may be touched.
+    ///
+    /// Known limitations (these constructs in templates may yield an incomplete schema):
+    /// <list type="bullet">
+    ///   <item>Sub-template formatters (<c>:tmpl</c>): the referenced sub-template is itself a template
+    ///   string at run-time and not visible to static analysis.</item>
+    ///   <item>Dynamic table contents (<c>:dyntable</c>): row/column data comes from a runtime
+    ///   <see cref="DocxTemplater.Model.IDynamicTable"/>; only the collection itself is reported.</item>
+    ///   <item>Dictionary-style indexing with string keys (<c>props["key"]</c>) is not reflected
+    ///   in the schema — the key is not statically known.</item>
+    /// </list>
+    /// </remarks>
+    public sealed class TemplateSchema
+    {
+        internal TemplateSchema(IReadOnlyDictionary<string, TemplateSchemaNode> roots)
+        {
+            Roots = roots;
+        }
+
+        /// <summary>
+        /// Root nodes of the schema, keyed by name (case-insensitive).
+        /// Each entry corresponds to a top-level model that callers would pass to
+        /// <see cref="TemplateProcessor.BindModel"/>.
+        /// </summary>
+        public IReadOnlyDictionary<string, TemplateSchemaNode> Roots { get; }
+    }
+}

--- a/DocxTemplater/Schema/TemplateSchemaNode.cs
+++ b/DocxTemplater/Schema/TemplateSchemaNode.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+
+namespace DocxTemplater.Schema
+{
+    /// <summary>
+    /// A node in the structural schema of variables referenced by a template.
+    /// Nodes form a tree rooted at <see cref="TemplateSchema.Roots"/>.
+    /// </summary>
+    public sealed class TemplateSchemaNode
+    {
+        private readonly Dictionary<string, TemplateSchemaNode> m_properties;
+
+        internal TemplateSchemaNode(string name, TemplateNodeKind kind)
+        {
+            Name = name;
+            Kind = kind;
+            m_properties = new Dictionary<string, TemplateSchemaNode>(System.StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Name of this node as it appears in the template (case-insensitive lookups against the model).
+        /// For <see cref="TemplateNodeKind.Collection"/> item schemas this is the collection's name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Kind of this node — scalar, object, or collection.
+        /// </summary>
+        public TemplateNodeKind Kind { get; private set; }
+
+        /// <summary>
+        /// Properties of an <see cref="TemplateNodeKind.Object"/> node (case-insensitive keys).
+        /// Empty for scalars and collections.
+        /// </summary>
+        public IReadOnlyDictionary<string, TemplateSchemaNode> Properties => m_properties;
+
+        /// <summary>
+        /// Shape of an element for <see cref="TemplateNodeKind.Collection"/> nodes.
+        /// <c>null</c> for non-collections, or when the collection's items are never accessed in the template.
+        /// </summary>
+        public TemplateSchemaNode ItemSchema { get; private set; }
+
+        internal void PromoteToObject()
+        {
+            if (Kind == TemplateNodeKind.Scalar)
+            {
+                Kind = TemplateNodeKind.Object;
+            }
+        }
+
+        internal void PromoteToCollection()
+        {
+            Kind = TemplateNodeKind.Collection;
+        }
+
+        internal TemplateSchemaNode GetOrAddProperty(string name)
+        {
+            PromoteToObject();
+            if (!m_properties.TryGetValue(name, out var child))
+            {
+                child = new TemplateSchemaNode(name, TemplateNodeKind.Scalar);
+                m_properties[name] = child;
+            }
+            return child;
+        }
+
+        internal TemplateSchemaNode EnsureItemSchema()
+        {
+            PromoteToCollection();
+            ItemSchema ??= new TemplateSchemaNode(Name, TemplateNodeKind.Object);
+            return ItemSchema;
+        }
+    }
+}

--- a/DocxTemplater/TemplateProcessor.cs
+++ b/DocxTemplater/TemplateProcessor.cs
@@ -27,22 +27,20 @@ namespace DocxTemplater
 
         protected void ProcessNode(OpenXmlCompositeElement rootElement)
         {
-#if DEBUG
-            Console.WriteLine("----------- Original --------");
-            Console.WriteLine(rootElement.ToPrettyPrintXml());
-#endif
-            PreProcess(rootElement);
+            var loops = BuildBlockTree(rootElement);
+            RenderNode(rootElement, loops);
+        }
 
-            var matches = DocxTemplate.IsolateAndMergeTextTemplateMarkers(rootElement);
-
-            RemoveLineBreaksAroundSyntaxPatterns(matches);
-
-#if DEBUG
-            Console.WriteLine("----------- Isolate Texts --------");
-            Console.WriteLine(rootElement.ToPrettyPrintXml());
-#endif
-
-            var loops = ExpandLoops(rootElement, matches);
+        /// <summary>
+        /// Renders the model into a node whose block tree has already been built by
+        /// <see cref="BuildBlockTree"/>. This is the model-dependent half of the pipeline
+        /// (variable replacement, extension rendering, loop/condition expansion, cleanup).
+        /// Splitting it out lets <see cref="DocxTemplate.GetTemplateSchema"/> build the tree once
+        /// and have <see cref="DocxTemplate.Process"/> reuse it instead of rebuilding (which would
+        /// fail on the already-mutated tree).
+        /// </summary>
+        private protected void RenderNode(OpenXmlCompositeElement rootElement, IReadOnlyCollection<ContentBlock> loops)
+        {
 #if DEBUG
             Console.WriteLine("----------- After Loops --------");
             Console.WriteLine(rootElement.ToPrettyPrintXml());
@@ -299,6 +297,30 @@ namespace DocxTemplater
         public void RegisterExtension(ITemplateProcessorExtension extension)
         {
             Context.RegisterExtension(extension);
+        }
+
+        /// <summary>
+        /// Runs the model-independent half of the pipeline: pre-process + isolate-text +
+        /// block-tree-build, without expanding/rendering any block. Returns the top-level blocks.
+        /// The document is mutated (marker attributes added, insertion points inserted, content
+        /// extracted into blocks), but the result is exactly the state <see cref="RenderNode"/>
+        /// expects. <see cref="DocxTemplate.GetTemplateSchema"/> caches the returned blocks so that a
+        /// subsequent <see cref="DocxTemplate.Process"/> can render from them instead of rebuilding.
+        /// </summary>
+        internal IReadOnlyCollection<ContentBlock> BuildBlockTree(OpenXmlCompositeElement rootElement)
+        {
+#if DEBUG
+            Console.WriteLine("----------- Original --------");
+            Console.WriteLine(rootElement.ToPrettyPrintXml());
+#endif
+            PreProcess(rootElement);
+            var matches = IsolateAndMergeTextTemplateMarkers(rootElement);
+            RemoveLineBreaksAroundSyntaxPatterns(matches);
+#if DEBUG
+            Console.WriteLine("----------- Isolate Texts --------");
+            Console.WriteLine(rootElement.ToPrettyPrintXml());
+#endif
+            return ExpandLoops(rootElement, matches);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ _DocxTemplater is a library to generate docx documents from a docx template. The
 - Markdown Support - Converts Markdown to OpenXML
 - HTML Snippets - Replace placeholder with HTML Content
 - Dynamic Tables - Columns are defined by the datasource
+- Template Schema - Statically inspect which variables a template expects, without rendering
 
 ## Quickstart
 
@@ -432,6 +433,53 @@ public class PersonModel : TemplateModelWithDisplayNames
 ```
 
 In your template, you can then use either `{{person.Vorname}}` or `{{person.FirstName}}` to access the property.
+
+## Template Schema Inspection
+
+`GetTemplateSchema()` statically analyzes a template **without rendering it** and returns the structural schema of the variables, collections, and nested objects the template references.
+Use it to validate a caller's model against the template's expectations before rendering, or to generate a skeleton model for callers to fill in.
+
+```csharp
+using var template = DocxTemplate.Open("template.docx");
+
+// Template: "Hello {{customer.Name}}" and "{{#items}}{{items.Price}}{{/items}}"
+var schema = template.GetTemplateSchema();
+
+// Roots are the top-level models you would pass to BindModel (case-insensitive)
+foreach (var root in schema.Roots.Values)
+{
+    Console.WriteLine($"{root.Name}: {root.Kind}");
+}
+
+schema.Roots["customer"].Properties["Name"].Kind;          // Scalar
+schema.Roots["items"].Kind;                                // Collection
+schema.Roots["items"].ItemSchema.Properties["Price"].Kind; // Scalar
+```
+
+Each `TemplateSchemaNode` exposes:
+
+| Member        | Description                                                                 |
+|---------------|-----------------------------------------------------------------------------|
+| `Name`        | Name as referenced in the template (case-insensitive against the model).    |
+| `Kind`        | `Scalar`, `Object`, or `Collection`.                                        |
+| `Properties`  | Child properties of an `Object` node (empty for scalars/collections).       |
+| `ItemSchema`  | Element shape of a `Collection` node (`null` if items are never accessed).  |
+
+The schema is the **union over all branches** (both `if` and `else`, every `case`, every loop body) - a caller must be prepared to bind anything the template could reach at runtime.
+
+`GetTemplateSchema()` may be called before `Process()` on the same instance; the analysis result is cached and reused when rendering, so there is no need to reopen the template:
+
+```csharp
+using var template = DocxTemplate.Open("template.docx");
+var schema = template.GetTemplateSchema();   // inspect
+template.BindModel("customer", customer);
+template.Save("generated.docx");             // render - reuses the cached analysis
+```
+
+**Known limitations** (these constructs may yield an incomplete schema):
+- Sub-template formatters (`:tmpl`): the referenced sub-template is itself a runtime template string and not visible to static analysis.
+- Dynamic tables (`:dyntable`): only the collection itself is reported, not its runtime-defined rows/columns.
+- String-key indexing (`props["key"]`): the key is not statically known and is not reflected in the schema.
 
 ## Support This Project
 


### PR DESCRIPTION
## Template Schema Inspection — `GetTemplateSchema()`

Adds a static analysis API that inspects a template **without rendering it** and returns the structural schema of the variables, collections and nested objects the template references. Callers can validate their model against the template's expectations up front, or generate a skeleton model to fill in.

### Public API

```csharp
using var template = DocxTemplate.Open("template.docx");

// Template: "Hello {{customer.Name}}" and "{{#items}}{{items.Price}}{{/items}}"
var schema = template.GetTemplateSchema();

schema.Roots["customer"].Properties["Name"].Kind;          // Scalar
schema.Roots["items"].Kind;                                // Collection
schema.Roots["items"].ItemSchema.Properties["Price"].Kind; // Scalar
```

| Type | Description |
|------|-------------|
| `DocxTemplate.GetTemplateSchema()` → `TemplateSchema` | Returns the template's schema. |
| `TemplateSchema` | `Roots` = top-level models (case-insensitive), matching the `BindModel` prefixes. |
| `TemplateSchemaNode` | `Name`, `Kind`, `Properties` (objects), `ItemSchema` (collections). |
| `TemplateNodeKind` | `Scalar` \| `Object` \| `Collection`. |

### What is covered

The schema is collected from the block tree and covers:

- **Variables & expressions** (`{{x}}`, `{{(a + b)}}`) — expression operands parsed via `SchemaExpressionParser`.
- **Loops / collections** (`{{#items}}…{{/items}}`) including nested item schemas and references to outer models.
- **Conditions (`if`/`else`), `switch`/`case`/`default`** — reported as the **union of all branches**, so a caller must be prepared to bind anything reachable at runtime.
- **Range loops, inline keywords, ignore blocks.**

Each block type contributes through a new `CollectSchema(SchemaBuilder)` method (base in `ContentBlock`, overrides in `LoopBlock`, `ConditionalBlock`, `SwitchBlock`/`CaseBlock`, `RangeLoopBlock`, `IgnoreBlock`, `InlineKeyWordBlock`).

### Schema and rendering on the same instance

`GetTemplateSchema()` builds the same block tree the renderer uses (which mutates the XML). To keep `Process()` working afterwards, the pipeline was split into two phases:

- **`BuildBlockTree`** — pre-process + marker isolation + loop expansion → **model-independent**.
- **`RenderNode`** — variable replacement + extensions + `loop.Expand` + cleanup → model-dependent.
- `ProcessNode` = `BuildBlockTree` + `RenderNode` (unchanged behaviour for existing callers).

`GetTemplateSchema()` caches the built block tree per node (header/body/footer) and the resulting `TemplateSchema`; `Process()` then renders from the cache instead of rebuilding the already-extracted tree. The previous *"destructive — do not call `Process` afterwards, reopen the stream"* contract is removed.

Guards / idempotency:
- A second `GetTemplateSchema()` call returns the cached result.
- Calling `GetTemplateSchema()` **after** `Process()` throws a clear exception.
- `Process()` without a prior schema call, or called twice, behaves as before.

### Known limitations (documented on `TemplateSchema`)

- **Sub-templates** (`:tmpl`): the referenced sub-template is a runtime template string, invisible to static analysis.
- **Dynamic tables** (`:dyntable`): only the collection itself is reported, not its runtime-defined rows/columns.
- **String-key indexing** (`props["key"]`): the key is not statically known and is not reflected in the schema.

### Tests

- New: `TemplateSchemaTest`, `SchemaBuilderTest`, `SchemaExpressionParserTest`.
- `ComplexTemplateTest.ProcessComplexTemplate` extended to call `GetTemplateSchema()` then `Process()` on the same instance.
- All schema tests (41/41) and `ProcessComplexTemplate` (3/3) pass on net8.0 / net9.0 / net10.0.

### Docs

README gains a *Template Schema Inspection* section and a feature bullet.
