### PR TITLE
Add support for configurable template delimiters

### DIFF
--- a/DocxTemplater.Test/PatternMatcherTest.cs
+++ b/DocxTemplater.Test/PatternMatcherTest.cs
@@ -9,7 +9,7 @@ namespace DocxTemplater.Test
         [Test, TestCaseSource(nameof(TestPatternMatch_Cases))]
         public PatternType[] TestPatternMatch(string input)
         {
-            var matches = PatternMatcher.FindSyntaxPatterns(input);
+            var matches = PatternMatcher.Default.FindSyntaxPatterns(input);
             foreach (var match in matches)
             {
                 Assert.That(match.Match.Value.First(), Is.EqualTo('{'));
@@ -98,7 +98,7 @@ namespace DocxTemplater.Test
         [Test, TestCaseSource(nameof(PatternMatcherArgumentParsingTest_Cases))]
         public string[] PatternMatcherArgumentParsingTest(string syntax)
         {
-            var match = PatternMatcher.FindSyntaxPatterns(syntax).First();
+            var match = PatternMatcher.Default.FindSyntaxPatterns(syntax).First();
             return match.Arguments;
         }
 
@@ -138,7 +138,7 @@ namespace DocxTemplater.Test
         [TestCase("Some TExt {{ Variable }} Some other text", ExpectedResult = "Variable")]
         public string AllowWhiteSpaceForVariables(string syntax)
         {
-            var match = PatternMatcher.FindSyntaxPatterns(syntax).First();
+            var match = PatternMatcher.Default.FindSyntaxPatterns(syntax).First();
             return match.Variable;
         }
 
@@ -148,7 +148,7 @@ namespace DocxTemplater.Test
         [TestCase("{?{ds.QrBills._Idx}}", ExpectedResult = "ds.QrBills._Idx")]
         public string TestConditionExpression(string syntax)
         {
-            var match = PatternMatcher.FindSyntaxPatterns(syntax).First();
+            var match = PatternMatcher.Default.FindSyntaxPatterns(syntax).First();
             Assert.That(match.Type, Is.EqualTo(PatternType.Condition));
             return match.Condition;
         }
@@ -157,7 +157,7 @@ namespace DocxTemplater.Test
         public void FindSyntax_SwitchCaseStatements()
         {
             var text = "{{#switch: Item.Value}}...{{#case: 'A'}}...{{/}}...{{#default}}...{{/}}...{{/}}";
-            var matches = PatternMatcher.FindSyntaxPatterns(text).ToList();
+            var matches = PatternMatcher.Default.FindSyntaxPatterns(text).ToList();
             Assert.Multiple(() =>
             {
                 Assert.That(matches, Has.Count.EqualTo(6));
@@ -175,32 +175,32 @@ namespace DocxTemplater.Test
         {
             // The :<value> suffix must NOT be parsed for regular collection variables.
             // {{#Items:foo}} should return 0 matches because colon syntax is only valid for switch/case or range loops.
-            var matches = PatternMatcher.FindSyntaxPatterns("{{#Items:foo}}").ToList();
+            var matches = PatternMatcher.Default.FindSyntaxPatterns("{{#Items:foo}}").ToList();
             Assert.That(matches, Has.Count.EqualTo(0));
 
             // {{Foo:Bar}} without prefix: colon should be treated as formatter separator, not varname
-            var noPrefix = PatternMatcher.FindSyntaxPatterns("{{Foo:Bar}}").ToList();
+            var noPrefix = PatternMatcher.Default.FindSyntaxPatterns("{{Foo:Bar}}").ToList();
             Assert.That(noPrefix, Has.Count.EqualTo(1));
             Assert.That(noPrefix[0].Type, Is.EqualTo(PatternType.Variable));
 
             // Dot-separated variable names must still work as normal collection starts.
-            var dotMatches = PatternMatcher.FindSyntaxPatterns("{{#Items.foo}}").ToList();
+            var dotMatches = PatternMatcher.Default.FindSyntaxPatterns("{{#Items.foo}}").ToList();
             Assert.That(dotMatches, Has.Count.EqualTo(1));
             Assert.That(dotMatches[0].Type, Is.EqualTo(PatternType.CollectionStart));
             Assert.That(dotMatches[0].Variable, Is.EqualTo("Items.foo"));
 
             // Range loops with @ prefix SHOULD accept colon syntax
-            var rangeMatches = PatternMatcher.FindSyntaxPatterns("{{@i:count}}").ToList();
+            var rangeMatches = PatternMatcher.Default.FindSyntaxPatterns("{{@i:count}}").ToList();
             Assert.That(rangeMatches, Has.Count.EqualTo(1));
             Assert.That(rangeMatches[0].Type, Is.EqualTo(PatternType.RangeStart));
             Assert.That(rangeMatches[0].Variable, Is.EqualTo("i:count"));
 
             // switch/case keywords SHOULD capture the :<value> suffix
-            var switchMatches = PatternMatcher.FindSyntaxPatterns("{{#switch: MyVar}}").ToList();
+            var switchMatches = PatternMatcher.Default.FindSyntaxPatterns("{{#switch: MyVar}}").ToList();
             Assert.That(switchMatches, Has.Count.EqualTo(1));
             Assert.That(switchMatches[0].Type, Is.EqualTo(PatternType.Switch));
 
-            var caseMatches = PatternMatcher.FindSyntaxPatterns("{{#case: 'A'}}").ToList();
+            var caseMatches = PatternMatcher.Default.FindSyntaxPatterns("{{#case: 'A'}}").ToList();
             Assert.That(caseMatches, Has.Count.EqualTo(1));
             Assert.That(caseMatches[0].Type, Is.EqualTo(PatternType.Case));
         }
@@ -210,7 +210,94 @@ namespace DocxTemplater.Test
         {
             // {{@}} without a variable name should throw
             Assert.Throws<OpenXmlTemplateException>(() =>
-                PatternMatcher.FindSyntaxPatterns("{{@}}").ToList());
+                PatternMatcher.Default.FindSyntaxPatterns("{{@}}").ToList());
+        }
+
+        [Test]
+        public void CustomDelimiters_AngleBrackets_MatchVariable()
+        {
+            var matcher = new PatternMatcher("<<", ">>");
+            var matches = matcher.FindSyntaxPatterns("<<Foo>>").ToList();
+            Assert.That(matches, Has.Count.EqualTo(1));
+            Assert.That(matches[0].Type, Is.EqualTo(PatternType.Variable));
+            Assert.That(matches[0].Variable, Is.EqualTo("Foo"));
+        }
+
+        [Test]
+        public void CustomDelimiters_AngleBrackets_MatchCondition()
+        {
+            var matcher = new PatternMatcher("<<", ">>");
+            // Conditional syntax: outer-open + '?' + inner-open  →  '<?<' for '<<' delimiter
+            // (same pattern as '{?{' for '{{')
+            // Note: conditions cannot contain the inner close char ('>') when using ">>" as delimiter.
+            var matches = matcher.FindSyntaxPatterns("<?<IsActive>>").ToList();
+            Assert.That(matches, Has.Count.EqualTo(1));
+            Assert.That(matches[0].Type, Is.EqualTo(PatternType.Condition));
+            Assert.That(matches[0].Condition.Trim(), Is.EqualTo("IsActive"));
+        }
+
+        [Test]
+        public void CustomDelimiters_AngleBrackets_MatchLoopStartAndEnd()
+        {
+            var matcher = new PatternMatcher("<<", ">>");
+            var matches = matcher.FindSyntaxPatterns("<<#items>>content<</items>>").ToList();
+            Assert.That(matches, Has.Count.EqualTo(2));
+            Assert.That(matches[0].Type, Is.EqualTo(PatternType.CollectionStart));
+            Assert.That(matches[1].Type, Is.EqualTo(PatternType.CollectionEnd));
+        }
+
+        [Test]
+        public void CustomDelimiters_AngleBrackets_MatchVariableWithFormatter()
+        {
+            var matcher = new PatternMatcher("<<", ">>");
+            var matches = matcher.FindSyntaxPatterns("<<Foo>:toupper>").ToList();
+            Assert.That(matches, Has.Count.EqualTo(1));
+            Assert.That(matches[0].Type, Is.EqualTo(PatternType.Variable));
+            Assert.That(matches[0].Variable, Is.EqualTo("Foo"));
+            Assert.That(matches[0].Formatter, Is.EqualTo("toupper"));
+        }
+
+        [Test]
+        public void CustomDelimiters_AngleBrackets_MatchConditionEnd()
+        {
+            var matcher = new PatternMatcher("<<", ">>");
+            var matches = matcher.FindSyntaxPatterns("<</ >>").ToList();
+            Assert.That(matches, Has.Count.EqualTo(1));
+            Assert.That(matches[0].Type, Is.EqualTo(PatternType.ConditionEnd));
+        }
+
+        [Test]
+        public void CustomDelimiters_DefaultSyntaxNotRecognized()
+        {
+            var matcher = new PatternMatcher("<<", ">>");
+            var matches = matcher.FindSyntaxPatterns("{{Foo}}").ToList();
+            Assert.That(matches, Is.Empty);
+        }
+
+        [TestCase(null, "}}")]
+        [TestCase("", "}}")]
+        [TestCase("{", "}}")]
+        [TestCase("{{", null)]
+        [TestCase("{{", "")]
+        [TestCase("{{", "}")]
+        [TestCase("{{", "{{")]
+        public void CustomDelimiters_InvalidArguments_ThrowsArgumentException(string open, string close)
+        {
+            Assert.Throws<ArgumentException>(() => new PatternMatcher(open, close));
+        }
+
+        [Test]
+        public void CustomDelimiters_ProcessSettings_UsedByDefault()
+        {
+            var settings = new ProcessSettings
+            {
+                OpenDelimiter = "<<",
+                CloseDelimiter = ">>"
+            };
+            var matcher = settings.PatternMatcher;
+            var matches = matcher.FindSyntaxPatterns("<<MyVar>>").ToList();
+            Assert.That(matches, Has.Count.EqualTo(1));
+            Assert.That(matches[0].Variable, Is.EqualTo("MyVar"));
         }
     }
 }

--- a/DocxTemplater.Test/SplitPlaceholderTest.cs
+++ b/DocxTemplater.Test/SplitPlaceholderTest.cs
@@ -107,7 +107,7 @@ namespace DocxTemplater.Test
                     </w:p>";
             var paragraph = new Paragraph(xml);
             var characterMap = new CharacterMap(paragraph);
-            foreach (var m in PatternMatcher.FindSyntaxPatterns(characterMap.Text))
+            foreach (var m in PatternMatcher.Default.FindSyntaxPatterns(characterMap.Text))
             {
                 var firstChar = characterMap[m.Index];
                 var lastChar = characterMap[m.Index + m.Length - 1];

--- a/DocxTemplater/Blocks/ContentBlock.cs
+++ b/DocxTemplater/Blocks/ContentBlock.cs
@@ -111,7 +111,7 @@ namespace DocxTemplater.Blocks
         /// </summary>
         public virtual void CollectSchema(SchemaBuilder builder)
         {
-            CollectMarkedVariables(m_content, builder);
+            CollectMarkedVariables(m_content, builder, m_context.ProcessSettings.PatternMatcher);
             foreach (var child in m_childBlocks)
             {
                 child.CollectSchema(builder);
@@ -125,7 +125,7 @@ namespace DocxTemplater.Blocks
         /// <c>{{...}}</c> pattern after the run-merge pass, so we recover the match without
         /// walking the document tree manually.
         /// </summary>
-        internal static void CollectMarkedVariables(IEnumerable<OpenXmlElement> elements, SchemaBuilder builder)
+        internal static void CollectMarkedVariables(IEnumerable<OpenXmlElement> elements, SchemaBuilder builder, PatternMatcher patternMatcher)
         {
             if (elements == null)
             {
@@ -138,7 +138,7 @@ namespace DocxTemplater.Blocks
                     .OfType<Text>();
                 foreach (var text in marked)
                 {
-                    var match = PatternMatcher.FindSyntaxPatterns(text.Text).FirstOrDefault();
+                    var match = patternMatcher.FindSyntaxPatterns(text.Text).FirstOrDefault();
                     if (match == null)
                     {
                         continue;

--- a/DocxTemplater/DocxTemplate.cs
+++ b/DocxTemplater/DocxTemplate.cs
@@ -201,7 +201,7 @@ namespace DocxTemplater
             m_prebuiltBlocks[rootElement] = rootBlocks;
             // Root-level variables outside any block remain as marked Text nodes in the rootElement
             // after the block-tree pipeline extracts each block's content. Pick those up directly.
-            ContentBlock.CollectMarkedVariables([rootElement], builder);
+            ContentBlock.CollectMarkedVariables([rootElement], builder, Context.ProcessSettings.PatternMatcher);
             foreach (var block in rootBlocks)
             {
                 block.CollectSchema(builder);

--- a/DocxTemplater/Extensions/Charts/ChartProcessor.cs
+++ b/DocxTemplater/Extensions/Charts/ChartProcessor.cs
@@ -92,7 +92,7 @@ namespace DocxTemplater.Extensions.Charts
                         var title = chartTitle.Descendants<DocumentFormat.OpenXml.Drawing.Text>().FirstOrDefault();
                         if (title != null)
                         {
-                            var found = PatternMatcher.FindSyntaxPatterns(title.Text).FirstOrDefault();
+                            var found = templateContext.ProcessSettings.PatternMatcher.FindSyntaxPatterns(title.Text).FirstOrDefault();
                             if (found != null && found.Type == PatternType.Variable)
                             {
                                 try

--- a/DocxTemplater/Formatter/VariableReplacer.cs
+++ b/DocxTemplater/Formatter/VariableReplacer.cs
@@ -90,7 +90,7 @@ namespace DocxTemplater.Formatter
                 return;
             }
 
-            var formatterText = GetFormatterText(patternMatch, valueWithMetadata, out string[] formatterArguments);
+            var formatterText = GetFormatterText(patternMatch, valueWithMetadata, out string[] formatterArguments, templateContext.ProcessSettings.PatternMatcher);
             ApplyFormatterInternal(templateContext, patternMatch, value, target, formatterText, formatterArguments);
         }
 
@@ -101,7 +101,7 @@ namespace DocxTemplater.Formatter
                 target.Text = string.Empty;
                 return;
             }
-            var formatterText = GetFormatterText(patternMatch, new ValueWithMetadata(value, new ValueMetadata()), out string[] formatterArguments);
+            var formatterText = GetFormatterText(patternMatch, new ValueWithMetadata(value, new ValueMetadata()), out string[] formatterArguments, templateContext.ProcessSettings.PatternMatcher);
             ApplyFormatterInternal(templateContext, patternMatch, value, target, formatterText, formatterArguments);
         }
 
@@ -147,7 +147,7 @@ namespace DocxTemplater.Formatter
                 .OfType<Text>().ToList();
             foreach (var text in variables)
             {
-                var variableMatch = PatternMatcher.FindSyntaxPatterns(text.Text).FirstOrDefault() ??
+                var variableMatch = templateContext.ProcessSettings.PatternMatcher.FindSyntaxPatterns(text.Text).FirstOrDefault() ??
                                     throw new OpenXmlTemplateException($"Invalid variable syntax '{text.Text}'");
                 try
                 {
@@ -187,7 +187,7 @@ namespace DocxTemplater.Formatter
         /// set through <see cref="ModelPropertyAttribute"/>
         /// </summary>
         private static string GetFormatterText(PatternMatch patternMatch, ValueWithMetadata valueWithMetadata,
-            out string[] formatterArguments)
+            out string[] formatterArguments, PatternMatcher patternMatcher)
         {
             formatterArguments = patternMatch.Arguments;
             var formatterText = patternMatch.Formatter;
@@ -196,8 +196,8 @@ namespace DocxTemplater.Formatter
                 if (!string.IsNullOrWhiteSpace(valueWithMetadata.Metadata.DefaultFormatter))
                 {
                     // try to parse default formatter from metadata
-                    var found = PatternMatcher
-                        .FindSyntaxPatterns("{{x}:" + valueWithMetadata.Metadata.DefaultFormatter + "}")
+                    var found = patternMatcher
+                        .FindSyntaxPatterns(patternMatcher.BuildFormatterCheckSyntax(valueWithMetadata.Metadata.DefaultFormatter))
                         .FirstOrDefault();
                     if (found != null && !string.IsNullOrWhiteSpace(found.Formatter))
                     {

--- a/DocxTemplater/PatterMatcher.cs
+++ b/DocxTemplater/PatterMatcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace DocxTemplater
@@ -16,7 +17,7 @@ namespace DocxTemplater
         int Index,
         int Length);
 
-    internal static class PatternMatcher
+    internal class PatternMatcher
     {
         /* matches:
         {{a > 5}} -- conditional - only capture
@@ -28,65 +29,30 @@ namespace DocxTemplater
         {{images}:foo(arg1,arg2)} -- variable with formatter and arguments
          */
 
-        private static readonly Regex PatternRegex = new(@"\{\s*(?<condMarker>\?\s*)?\{\s*
-        (?:   
-            (?<separator>:\s*s\s*:) |
-            (?<else>(?:else|:(?!\s*[^\s}]+))) |  # Match : only if nothing but whitespace follows before }
-            (?(condMarker)
-                (?<condition>[^}]+) # allow any character except }
-                |
-                (?:
-                    (?<prefix>[\/\#:@]{1,2})?
-                    (?:
-                        (?<varname>  # Constrain Switch/Case capturing to strictly known prefix variables
-                            (?i:switch|s|case|c)
-                            (?:
-                                \s*:\s* # match colon for switch/case
-                                (?:
-                                    (?:'[^']*') | # match single quotes
-                                    (?:""[^""]*"") | # match double quotes
-                                    [\p{L}\p{N}\._()]+ # match unquoted values
-                                )
-                            )?
-                        )
-                        |
-                        (?<varname> # Range loop pattern: identifier:count
-                            [\p{L}\p{N}\._]+
-                            :
-                            [\p{L}\p{N}\._]+
-                        )
-                        |
-                        (?<varname> # the default variable matcher
-                            [\p{L}\p{N}\._]+ # match variable name
-                        )
-                        |
-                        (?<expression> # the expression matcher
-                            \(
-                            (?>[^()]+|(?<o>\()|(?<-o>\)))*
-                            \)
-                            (?(o)(?!))
-                        )
-                    )?
-                ) 
-            )
-        )
-        \s*\}
-        (?::
-            (?<formatter>[\p{L}\p{N}]+)
-            (?:\(
-                (?:
-                   (?:
-                       (?:'(?<arg>(?:(?:\\['])|[^'}])*?)'|""""(?<arg>(?:(?:\\[""""])|[^""""}])*?)"""") # Allow any character except ' and } in quoted strings
-                        |
-                        (?<arg>[^,)}]+) # Allow any character except delimiters in unquoted strings
-                    )(?:\s*,\s*)?
-                )*
-                \))?
-        )?
-        \s*\}
-        ", RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, TimeSpan.FromSeconds(1));
+        private readonly Regex _regex;
+        private readonly string _openDelimiter;
+        private readonly string _closeDelimiter;
 
-        public static IEnumerable<PatternMatch> FindSyntaxPatterns(string text)
+        internal static PatternMatcher Default { get; } = new("{{", "}}");
+
+        internal PatternMatcher(string openDelimiter, string closeDelimiter)
+        {
+            ValidateDelimiters(openDelimiter, closeDelimiter);
+            _openDelimiter = openDelimiter;
+            _closeDelimiter = closeDelimiter;
+            _regex = BuildRegex(openDelimiter, closeDelimiter);
+        }
+
+        /// <summary>
+        /// Builds the synthetic string used internally to parse a formatter spec from metadata,
+        /// e.g. "{{x}:F(n)}" for the default delimiters, or "&lt;&lt;x&gt;:F(n)&gt;" for "&lt;&lt;"/"&gt;&gt;" delimiters.
+        /// </summary>
+        internal string BuildFormatterCheckSyntax(string formatterSpec)
+        {
+            return _openDelimiter + "x" + _closeDelimiter[..^1] + ":" + formatterSpec + _closeDelimiter[^1..];
+        }
+
+        internal IEnumerable<PatternMatch> FindSyntaxPatterns(string text)
         {
             try
             {
@@ -95,7 +61,7 @@ namespace DocxTemplater
                     return Array.Empty<PatternMatch>();
                 }
 
-                var matches = PatternRegex.Matches(text);
+                var matches = _regex.Matches(text);
                 var result = new List<PatternMatch>(matches.Count);
                 foreach (Match match in matches)
                 {
@@ -220,9 +186,6 @@ namespace DocxTemplater
                             ? argGroup.Captures.Select(x => x.Value?.Replace("\\'", "'")).ToArray()
                             : Array.Empty<string>();
 
-                        // we want to extract the expression string but keep the original match structure similar to Variable
-                        // the expression group includes the outer parenthesis `(a > 5)`
-                        // let's pass the whole captured expression as the variable name for now, the block can trim if needed.
                         result.Add(new PatternMatch(match, PatternType.Expression, null, null,
                             match.Groups["expression"].Value,
                             match.Groups["formatter"].Value, arguments, match.Index, match.Length));
@@ -249,6 +212,126 @@ namespace DocxTemplater
             {
                 throw new OpenXmlTemplateException($"Invalid syntax '{text}' - match timeout");
             }
+        }
+
+        private static Regex BuildRegex(string open, string close)
+        {
+            // Split delimiter into outer char and inner chars:
+            //   open[0]     = outer open  (e.g. '{' for "{{")
+            //   open[1..]   = inner open  (e.g. '{' for "{{")
+            //   close[..^1] = inner close (e.g. '}' for "}}")
+            //   close[^1..] = outer close (e.g. '}' for "}}")
+            //
+            // For "<<" / ">>": outer='<', inner='<', inner-close='>', outer-close='>'
+            // Conditional syntax: outerOpen + '?' + innerOpen  (e.g. '{?{' or '<?<')
+            string eo = Regex.Escape(open[0].ToString());
+            string ei = Regex.Escape(open[1..]);
+            string c0 = Regex.Escape(close[..^1]);
+            string c1 = Regex.Escape(close[^1..]);
+            string cc0 = EscapeForCharClass(close[..^1]);
+            string dq = "\"\"";
+
+            // Build the full regex pattern. RegexOptions.IgnorePatternWhitespace is used so
+            // whitespace outside character classes is ignored, allowing readability via newlines.
+            string pattern =
+                eo + @"\s*(?<condMarker>\?\s*)?" + ei + @"\s*" +
+                @"(?:" +
+                    @"(?<separator>:\s*s\s*:) |" +
+                    @"(?<else>(?:else|:(?!\s*[^\s" + cc0 + @"]+))) |" +
+                    @"(?(condMarker)" +
+                        @"(?<condition>[^" + cc0 + @"]+)" +
+                        @"|" +
+                        @"(?:" +
+                            @"(?<prefix>[\/\#:@]{1,2})?" +
+                            @"(?:" +
+                                @"(?<varname>" +
+                                    @"(?i:switch|s|case|c)" +
+                                    @"(?:" +
+                                        @"\s*:\s*" +
+                                        @"(?:" +
+                                            @"(?:'[^']*') |" +
+                                            @"(?:""[^""]*"") |" +
+                                            @"[\p{L}\p{N}\._()]+" +
+                                        @")" +
+                                    @")?" +
+                                @")" +
+                                @"|" +
+                                @"(?<varname>" +
+                                    @"[\p{L}\p{N}\._]+" +
+                                    @":" +
+                                    @"[\p{L}\p{N}\._]+" +
+                                @")" +
+                                @"|" +
+                                @"(?<varname>" +
+                                    @"[\p{L}\p{N}\._]+" +
+                                @")" +
+                                @"|" +
+                                @"(?<expression>" +
+                                    @"\(" +
+                                    @"(?>[^()]+|(?<o>\()|(?<-o>\)))*" +
+                                    @"\)" +
+                                    @"(?(o)(?!))" +
+                                @")" +
+                            @")?" +
+                        @")" +
+                    @")" +
+                @")" +
+                @"\s*" + c0 +
+                @"(?::" +
+                    @"(?<formatter>[\p{L}\p{N}]+)" +
+                    @"(?:\(" +
+                        @"(?:" +
+                            @"(?:" +
+                                "(?:'(?<arg>(?:(?:\\\\['])|[^'" + cc0 + "])*?)'|" +
+                                dq + "(?<arg>(?:(?:\\\\[" + dq + "])|[^" + dq[0] + cc0 + "])*?)" + dq +
+                                @")" +
+                                @"|" +
+                                "(?<arg>[^,)" + cc0 + "]+)" +
+                            @")(?:\s*,\s*)?" +
+                        @")*" +
+                        @"\))?" +
+                @")?" +
+                @"\s*" + c1;
+
+            return new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, TimeSpan.FromSeconds(1));
+        }
+
+        private static void ValidateDelimiters(string open, string close)
+        {
+            if (string.IsNullOrEmpty(open))
+            {
+                throw new ArgumentException("OpenDelimiter must not be null or empty.", nameof(open));
+            }
+            if (open.Length < 2)
+            {
+                throw new ArgumentException("OpenDelimiter must be at least 2 characters.", nameof(open));
+            }
+            if (string.IsNullOrEmpty(close))
+            {
+                throw new ArgumentException("CloseDelimiter must not be null or empty.", nameof(close));
+            }
+            if (close.Length < 2)
+            {
+                throw new ArgumentException("CloseDelimiter must be at least 2 characters.", nameof(close));
+            }
+            if (open == close)
+            {
+                throw new ArgumentException("OpenDelimiter and CloseDelimiter must not be the same.");
+            }
+        }
+
+        private static string EscapeForCharClass(string s)
+        {
+            var sb = new StringBuilder(s.Length * 2);
+            foreach (char c in s)
+            {
+                if (c is '\\' or ']' or '^' or '-')
+                {
+                    sb.Append('\\');
+                }
+                sb.Append(c);
+            }
+            return sb.ToString();
         }
     }
 }

--- a/DocxTemplater/ProcessSettings.cs
+++ b/DocxTemplater/ProcessSettings.cs
@@ -4,6 +4,9 @@ namespace DocxTemplater
 {
     public class ProcessSettings
     {
+        private string _openDelimiter = "{{";
+        private string _closeDelimiter = "}}";
+        private PatternMatcher _patternMatcher;
 
         /// <summary>
         /// Output culture of the document
@@ -13,11 +16,44 @@ namespace DocxTemplater
         public BindingErrorHandling BindingErrorHandling { get; set; } = BindingErrorHandling.ThrowException;
 
         /// <summary>
-        /// When enabled, this option removes leading or trailing newlines around template directives (e.g., {{#...}}, {{/}}) 
+        /// When enabled, this option removes leading or trailing newlines around template directives (e.g., {{#...}}, {{/}})
         /// from the final output. This allows templates to be more readable without affecting rendered formatting.
         /// default: false
         /// </summary>
         public bool IgnoreLineBreaksAroundTags { get; set; }
+
+        /// <summary>
+        /// The opening delimiter for template tags (default: "{{").
+        /// Must be at least 2 characters and different from <see cref="CloseDelimiter"/>.
+        /// Example: set to "&lt;&lt;" to use &lt;&lt;variable&gt;&gt; syntax.
+        /// </summary>
+        public string OpenDelimiter
+        {
+            get => _openDelimiter;
+            set
+            {
+                _openDelimiter = value;
+                _patternMatcher = null;
+            }
+        }
+
+        /// <summary>
+        /// The closing delimiter for template tags (default: "}}").
+        /// Must be at least 2 characters and different from <see cref="OpenDelimiter"/>.
+        /// Example: set to "&gt;&gt;" to use &lt;&lt;variable&gt;&gt; syntax.
+        /// </summary>
+        public string CloseDelimiter
+        {
+            get => _closeDelimiter;
+            set
+            {
+                _closeDelimiter = value;
+                _patternMatcher = null;
+            }
+        }
+
+        internal PatternMatcher PatternMatcher
+            => _patternMatcher ??= new PatternMatcher(_openDelimiter, _closeDelimiter);
 
         public static ProcessSettings Default => new();
     }

--- a/DocxTemplater/TemplateProcessor.cs
+++ b/DocxTemplater/TemplateProcessor.cs
@@ -119,11 +119,11 @@ namespace DocxTemplater
             }
         }
 
-        private static IReadOnlyCollection<(PatternMatch, Text)> IsolateAndMergeTextTemplateMarkers(OpenXmlCompositeElement content)
+        private static IReadOnlyCollection<(PatternMatch, Text)> IsolateAndMergeTextTemplateMarkers(OpenXmlCompositeElement content, PatternMatcher patternMatcher)
         {
             var charMap = new CharacterMap(content);
             List<(PatternMatch, Text)> patternMatches = [];
-            foreach (var m in PatternMatcher.FindSyntaxPatterns(charMap.Text))
+            foreach (var m in patternMatcher.FindSyntaxPatterns(charMap.Text))
             {
                 var firstChar = charMap[m.Index];
                 var lastChar = charMap[m.Index + m.Length - 1];
@@ -314,7 +314,7 @@ namespace DocxTemplater
             Console.WriteLine(rootElement.ToPrettyPrintXml());
 #endif
             PreProcess(rootElement);
-            var matches = IsolateAndMergeTextTemplateMarkers(rootElement);
+            var matches = IsolateAndMergeTextTemplateMarkers(rootElement, Context.ProcessSettings.PatternMatcher);
             RemoveLineBreaksAroundSyntaxPatterns(matches);
 #if DEBUG
             Console.WriteLine("----------- Isolate Texts --------");

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _DocxTemplater is a library to generate docx documents from a docx template. The
 - HTML Snippets - Replace placeholder with HTML Content
 - Dynamic Tables - Columns are defined by the datasource
 - Template Schema - Statically inspect which variables a template expects, without rendering
+- Custom Delimiters - Use any delimiter pair (e.g. `<<`/`>>`) instead of the default `{{`/`}}`
 
 ## Quickstart
 
@@ -396,6 +397,33 @@ var docTemplate = new DocxTemplate(memStream, new ProcessSettings()
 var result = docTemplate.Process();
 ```
 
+## Custom Delimiters
+
+By default, DocxTemplater uses `{{` and `}}` as template delimiters. You can change them to any two-character (or longer) sequence via `ProcessSettings`:
+
+```csharp
+var docTemplate = new DocxTemplate(memStream, new ProcessSettings()
+{
+    OpenDelimiter = "<<",
+    CloseDelimiter = ">>"
+});
+var result = docTemplate.Process();
+```
+
+With `<<`/`>>` delimiters, all template syntax works the same way — just replace `{{` and `}}`:
+
+| Default syntax | Custom syntax (`<<`/`>>`) |
+|---|---|
+| `{{ds.Name}}` | `<<ds.Name>>` |
+| `{{#ds.Items}}` / `{{/ds.Items}}` | `<<#ds.Items>>` / `<</ds.Items>>` |
+| `{?{ds.IsActive}}` / `{{/}}` | `<?<ds.IsActive>>` / `<</>>` |
+| `{{ds.Value}:toupper}` | `<<ds.Value>:toupper>` |
+
+**Constraints:**
+- Both delimiters must be at least 2 characters long.
+- Open and close delimiters must be different.
+
+---
 ## Advanced Model Binding: `ITemplateModel` and `TemplateModelWithDisplayNames`
 
 ### `ITemplateModel` Interface


### PR DESCRIPTION
## Summary

Allows users to specify custom open/close delimiters via `ProcessSettings` instead of being locked to the default `{{`/`}}` syntax.

```csharp
var docTemplate = new DocxTemplate(stream, new ProcessSettings()
{
    OpenDelimiter = "<<",
    CloseDelimiter = ">>"
});
```

Changes

- PatternMatcher refactored from a static class to an instance-based class with a Default singleton ({{/}})
- ProcessSettings exposes OpenDelimiter / CloseDelimiter properties with a lazy-cached PatternMatcher
- All internal pattern-matching call sites updated to use the instance from the active ProcessSettings
- Conditional syntax adapts automatically: the ? marker sits between the two characters of the open delimiter (e.g. <?< for <</>>)
- ValidateDelimiters enforces minimum length of 2 and open ≠ close

Tests

New test cases added in PatternMatcherTest covering variable, condition, loop, formatter, and error scenarios for custom delimiters.

---