### PR TITLE
Fix paragraph order when inserting docx documents via sub-template fo…

### DIFF
--- a/DocxTemplater.Test/DocxTemplateTest.cs
+++ b/DocxTemplater.Test/DocxTemplateTest.cs
@@ -968,6 +968,48 @@ namespace DocxTemplater.Test
             Assert.That(body.InnerText, Is.EqualTo("Start of DocumentItem1 Test Item1  55Item2 Test Item2  96"));
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SubTemplateInsertDocxDocument(bool bindAsStream)
+        {
+            // create the document to insert - it can itself contain placeholders
+            using var subDocStream = new MemoryStream();
+            using (var subDocument = WordprocessingDocument.Create(subDocStream, WordprocessingDocumentType.Document))
+            {
+                var subMainPart = subDocument.AddMainDocumentPart();
+                subMainPart.Document = new Document(new Body(
+                    new Paragraph(new Run(new Text("First inserted paragraph for {{ds.Name}}"))),
+                    new Paragraph(new Run(new Text("Second inserted paragraph")))));
+            }
+
+            using var memStream = new MemoryStream();
+            using var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document);
+            MainDocumentPart mainPart = wpDocument.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(
+                new Paragraph(new Run(new Text("Start of Document"))),
+                new Paragraph(new Run(new Text("{{ds}:template('ds.SubDocument')}"))),
+                new Paragraph(new Run(new Text("End of Document")))));
+            wpDocument.Save();
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new
+            {
+                Name = "John",
+                SubDocument = bindAsStream ? new MemoryStream(subDocStream.ToArray()) : (object)subDocStream.ToArray()
+            });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+            Assert.That(result, Is.Not.Null);
+            result.Position = 0;
+
+            var document = WordprocessingDocument.Open(result, false);
+            var body = document.MainDocumentPart.Document.Body;
+            // the body content of the sub document is inserted at the placeholder position
+            // and placeholders in the sub document are resolved against the bound model
+            Assert.That(body.InnerText, Is.EqualTo("Start of DocumentFirst inserted paragraph for JohnSecond inserted paragraphEnd of Document"));
+        }
+
         [Test]
         public void BindCollectionToTable()
         {

--- a/DocxTemplater/Formatter/SubTemplateFormatter.cs
+++ b/DocxTemplater/Formatter/SubTemplateFormatter.cs
@@ -57,10 +57,10 @@ namespace DocxTemplater.Formatter
             if (templateElement is Body body)
             {
                 var parent = target.GetFirstAncestor<Paragraph>() ?? throw new OpenXmlTemplateException("Could not find parent to insert template");
-                var firstPart = parent.SplitAfterElement(target).First();
+                OpenXmlElement insertionPoint = parent.SplitAfterElement(target).First();
                 foreach (var childParagaphs in body.ChildElements)
                 {
-                    firstPart.InsertAfterSelf(childParagaphs.CloneNode(true));
+                    insertionPoint = insertionPoint.InsertAfterSelf(childParagaphs.CloneNode(true));
                 }
             }
             else if (templateElement is Paragraph paragraph)

--- a/DocxTemplater/Schema/TemplateSchema.cs
+++ b/DocxTemplater/Schema/TemplateSchema.cs
@@ -12,7 +12,7 @@ namespace DocxTemplater.Schema
     ///
     /// Known limitations (these constructs in templates may yield an incomplete schema):
     /// <list type="bullet">
-    ///   <item>Sub-template formatters (<c>:tmpl</c>): the referenced sub-template is itself a template
+    ///   <item>Sub-template formatters (<c>:template</c> / <c>:T</c>): the referenced sub-template is itself a template
     ///   string at run-time and not visible to static analysis.</item>
     ///   <item>Dynamic table contents (<c>:dyntable</c>): row/column data comes from a runtime
     ///   <see cref="DocxTemplater.Model.IDynamicTable"/>; only the collection itself is reported.</item>

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The syntax is case insensitive.
 | `{{(ds.Items[0].Name)}}`                                 | Expressions with array / list / dictionary index access.                                        |
 | `{{SomeBytes}:img()}`                                    | Image Formatter for image data.                                                                 |
 | `{{SomeHtmlString}:html()}`                              | Inserts HTML string into the word document.                                                     |
+| `{{ds}:template('ds.SubDocument')}`                      | Inserts another docx document (or OpenXML fragment) at the placeholder position.               |
 | `{{@i:ItemCount}}...{{i}}...{{/}}`                       | Range loop that repeats its content `ItemCount` times.                                          |
 | `{{#Items}}{?{Items._Idx % 2 == 0}}{{.}}{{/}}{{/Items}}` | Renders every second item in a list.                                                            |
 | `{{#switch: SomeVar}}{{#case: 'A'}}...{{/}}{{#default}}...{{/}}{{/}}` | Evaluates switch cases and renders the matching block. there is a short syntax too                                          |
@@ -377,6 +378,42 @@ In your template, you would have a placeholder like this:
 {{ds.MarkdownContent}:MD}
 ```
 ---
+## Sub-Template Formatter - Inserting Documents
+
+The sub-template formatter `:template(...)` (short form `:T(...)`) replaces a placeholder with the content of another docx document or an OpenXML fragment. It is registered by default - no additional setup is required.
+
+The first argument is the path to the model property that holds the template to insert. The following types are supported:
+
+| Type                      | Description                                                                        |
+|---------------------------|------------------------------------------------------------------------------------|
+| `byte[]` / `Stream`       | A complete docx document - its body content is inserted at the placeholder position |
+| `string`                  | An OpenXML fragment (paragraph, run or text)                                        |
+| `OpenXmlCompositeElement` | An OpenXML element (paragraph, run, table row or table cell)                        |
+
+```csharp
+var template = DocxTemplate.Open("template.docx");
+template.BindModel("ds", new
+{
+    Name = "John",
+    SubDocument = File.ReadAllBytes("insert.docx") // byte[] or Stream
+});
+template.Save("generated.docx");
+```
+
+Placeholder in `template.docx`:
+```
+{{ds}:template('ds.SubDocument')}
+```
+
+The value in front of the formatter (here `ds`) is bound as `ds` *inside* the inserted document - so the inserted document can itself contain placeholders, which are resolved against that value. This also works inside loops, to render a sub-template once per item:
+
+```
+{{#ds.Items}}{{.}:T('ds.ItemTemplate')}{{/ds.Items}}
+```
+
+**_NOTE:_** The content is inserted by copying the OpenXML body elements into the host document. Styles, numbering definitions and images stored in the inserted document's own parts are not imported.
+
+---
 ## Whitespace Trimming Around Directives
 
 To improve template readability without affecting the final output, line breaks before and after template directives (e.g., `{{#...}}, {{/}}, {{:}}`) can be automatically removed.
@@ -490,7 +527,7 @@ template.Save("generated.docx");             // render - reuses the cached analy
 ```
 
 **Known limitations** (these constructs may yield an incomplete schema):
-- Sub-template formatters (`:tmpl`): the referenced sub-template is itself a runtime template string and not visible to static analysis.
+- Sub-template formatters (`:template` / `:T`): the referenced sub-template is itself a runtime template string and not visible to static analysis.
 - Dynamic tables (`:dyntable`): only the collection itself is reported, not its runtime-defined rows/columns.
 - String-key indexing (`props["key"]`): the key is not statically known and is not reflected in the schema.
 


### PR DESCRIPTION
…rmatter

Inserting a whole docx document (byte[] or Stream) with :template(...) reversed the paragraph order because every body child was inserted directly after the split point instead of after the last inserted element.

- Add test for inserting a docx document as byte[] and Stream (#132)
- Document the sub-template formatter in the README
- Fix wrong formatter prefix :tmpl in docs (correct: :template / :T)