### PR TITLE
Preserve images and links when inserting a document

### DIFF
--- a/DocxTemplater.Test/SubTemplateImageImportTest.cs
+++ b/DocxTemplater.Test/SubTemplateImageImportTest.cs
@@ -1,0 +1,113 @@
+﻿using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using A = DocumentFormat.OpenXml.Drawing;
+using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using PIC = DocumentFormat.OpenXml.Drawing.Pictures;
+
+namespace DocxTemplater.Test
+{
+    [TestFixture]
+    public class SubTemplateImageImportTest
+    {
+        // Regression test: when a document is inserted via the 'template' formatter, images embedded in the
+        // inserted document must be preserved. The body content is cloned into the target, so the referenced
+        // image part has to be copied into the target and the blip relationship id remapped - otherwise the
+        // r:embed dangles and the image is lost.
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SubTemplateInsert_PreservesEmbeddedImage(bool bindAsStream)
+        {
+            var imageBytes = File.ReadAllBytes("Resources/testImage.jpg");
+
+            // The document to insert: a placeholder (proves the deep merge still runs) and an embedded image.
+            using var subDocStream = new MemoryStream();
+            using (var subDocument = WordprocessingDocument.Create(subDocStream, WordprocessingDocumentType.Document))
+            {
+                var subMainPart = subDocument.AddMainDocumentPart();
+                subMainPart.Document = new Document(new Body());
+                var imagePart = subMainPart.AddImagePart(ImagePartType.Jpeg);
+                using (var imageStream = new MemoryStream(imageBytes))
+                {
+                    imagePart.FeedData(imageStream);
+                }
+                var relationshipId = subMainPart.GetIdOfPart(imagePart);
+                subMainPart.Document.Body.Append(
+                    new Paragraph(new Run(new Text("Inserted for {{ds.Name}}"))),
+                    new Paragraph(new Run(CreateInlineImage(relationshipId, 990000L, 792000L))));
+                subMainPart.Document.Save();
+            }
+
+            using var memStream = new MemoryStream();
+            using (var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wpDocument.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body(
+                    new Paragraph(new Run(new Text("Start of Document"))),
+                    new Paragraph(new Run(new Text("{{ds}:template('ds.SubDocument')}"))),
+                    new Paragraph(new Run(new Text("End of Document")))));
+            }
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new
+            {
+                Name = "John",
+                SubDocument = bindAsStream ? new MemoryStream(subDocStream.ToArray()) : (object)subDocStream.ToArray()
+            });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+            Assert.That(result, Is.Not.Null);
+            result.Position = 0;
+
+            using var document = WordprocessingDocument.Open(result, false);
+            var mainDocumentPart = document.MainDocumentPart;
+            var body = mainDocumentPart.Document.Body;
+
+            // Placeholder inside the inserted document was resolved (deep merge still works).
+            Assert.That(body.InnerText, Does.Contain("Inserted for John"));
+
+            // The inserted image is present and its relationship resolves to an image part in the target.
+            var blip = body.Descendants<A.Blip>().SingleOrDefault();
+            Assert.That(blip, Is.Not.Null, "the inserted image drawing should be present in the merged document");
+            Assert.That(blip.Embed?.Value, Is.Not.Null.And.Not.Empty);
+
+            var referencedPart = mainDocumentPart.GetPartById(blip.Embed.Value);
+            Assert.That(referencedPart, Is.InstanceOf<ImagePart>(), "the blip relationship must resolve to an image part in the target");
+
+            // The copied image has the same content as the source image.
+            using var copiedStream = ((ImagePart)referencedPart).GetStream();
+            using var copiedBytes = new MemoryStream();
+            copiedStream.CopyTo(copiedBytes);
+            Assert.That(copiedBytes.ToArray(), Is.EqualTo(imageBytes), "the image content must be copied into the target document");
+        }
+
+        private static Drawing CreateInlineImage(string relationshipId, long cx, long cy)
+        {
+            var picture = new PIC.Picture(
+                new PIC.NonVisualPictureProperties(
+                    new PIC.NonVisualDrawingProperties { Id = 0U, Name = "image.jpg" },
+                    new PIC.NonVisualPictureDrawingProperties()),
+                new PIC.BlipFill(
+                    new A.Blip { Embed = relationshipId },
+                    new A.Stretch(new A.FillRectangle())),
+                new PIC.ShapeProperties(
+                    new A.Transform2D(
+                        new A.Offset { X = 0L, Y = 0L },
+                        new A.Extents { Cx = cx, Cy = cy }),
+                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }));
+
+            var inline = new DW.Inline(
+                new DW.Extent { Cx = cx, Cy = cy },
+                new DW.DocProperties { Id = 1U, Name = "Picture 1" },
+                new A.Graphic(new A.GraphicData(picture) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/picture" }))
+            {
+                DistanceFromTop = 0U,
+                DistanceFromBottom = 0U,
+                DistanceFromLeft = 0U,
+                DistanceFromRight = 0U
+            };
+            return new Drawing(inline);
+        }
+    }
+}

--- a/DocxTemplater/Formatter/SubTemplateFormatter.cs
+++ b/DocxTemplater/Formatter/SubTemplateFormatter.cs
@@ -2,6 +2,7 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -10,10 +11,12 @@ namespace DocxTemplater.Formatter
     /// <summary>
     /// Formatter for inserting a template into the document
     /// Arguments:
-    /// 
+    ///
     /// </summary>
     internal class SubTemplateFormatter : IFormatter
     {
+        private const string RelationshipNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
         public bool CanHandle(Type type, string prefix)
         {
             return prefix.Equals("template", StringComparison.CurrentCultureIgnoreCase) ||
@@ -27,7 +30,15 @@ namespace DocxTemplater.Formatter
             {
                 throw new OpenXmlTemplateException("Template formatter requires a template name");
             }
-            var templateElement = LoadTemplateElements(formatterContext.Args[0]?.Trim(), templateContext.ModelLookup) ?? throw new OpenXmlTemplateException("Template is null or is not a valid OpenXML template");
+            var loaded = LoadTemplateElements(formatterContext.Args[0]?.Trim(), templateContext.ModelLookup);
+            // Keep the (optional) source document open until the merge completes, so its parts can be copied;
+            // disposed at the end of the method. Null for string / OpenXmlElement templates.
+            using var loadedSource = loaded.Source;
+            var templateElement = loaded.Element ?? throw new OpenXmlTemplateException("Template is null or is not a valid OpenXML template");
+
+            // Resolve the destination part up front: the table-row / -cell branches remove target's ancestor,
+            // after which target.GetRoot() can no longer reach the owning part.
+            var targetPart = (target.GetRoot() as OpenXmlPartRootElement)?.OpenXmlPart;
 
             if (formatterContext.Args.Length > 1)
             {
@@ -54,47 +65,153 @@ namespace DocxTemplater.Formatter
             var processor = new XmlNodeTemplate(templateElement, new TemplateProcessingContext(templateContext.ProcessSettings, templateModelLookup, variableReplacer, scriptCompiler));
             processor.Process();
 
+            // Elements cloned into the target document. Their relationship references (images, external links)
+            // still point at the source document's parts and must be re-imported / re-mapped below.
+            var insertedElements = new List<OpenXmlElement>();
+
             if (templateElement is Body body)
             {
                 var parent = target.GetFirstAncestor<Paragraph>() ?? throw new OpenXmlTemplateException("Could not find parent to insert template");
                 OpenXmlElement insertionPoint = parent.SplitAfterElement(target).First();
                 foreach (var childParagaphs in body.ChildElements)
                 {
-                    insertionPoint = insertionPoint.InsertAfterSelf(childParagaphs.CloneNode(true));
+                    var clone = childParagaphs.CloneNode(true);
+                    insertionPoint = insertionPoint.InsertAfterSelf(clone);
+                    insertedElements.Add(clone);
                 }
             }
             else if (templateElement is Paragraph paragraph)
             {
                 var parent = target.GetFirstAncestor<Paragraph>() ?? throw new OpenXmlTemplateException("Could not find parent to insert template");
                 var firstPart = parent.SplitAfterElement(target).First();
-                firstPart.InsertAfterSelf(paragraph.CloneNode(true));
+                insertedElements.Add(firstPart.InsertAfterSelf(paragraph.CloneNode(true)));
             }
             else if (templateElement is Run run)
             {
                 var parent = target.GetFirstAncestor<Run>() ?? throw new OpenXmlTemplateException("Could not find parent to insert template");
                 var firstPart = parent.SplitAfterElement(target).First();
-                firstPart.InsertAfterSelf(run.CloneNode(true));
+                insertedElements.Add(firstPart.InsertAfterSelf(run.CloneNode(true)));
             }
             else if (templateElement is TableRow row)
             {
                 var parent = target.GetFirstAncestor<TableRow>() ?? throw new OpenXmlTemplateException("Could not find parent to insert template");
-                parent.InsertAfterSelf(row.CloneNode(true));
+                insertedElements.Add(parent.InsertAfterSelf(row.CloneNode(true)));
                 parent.RemoveWithEmptyParent();
             }
             else if (templateElement is TableCell cell)
             {
                 var parent = target.GetFirstAncestor<TableCell>() ?? throw new OpenXmlTemplateException("Could not find parent to insert template");
-                parent.InsertAfterSelf(cell.CloneNode(true));
+                insertedElements.Add(parent.InsertAfterSelf(cell.CloneNode(true)));
                 parent.RemoveWithEmptyParent();
             }
             else
             {
                 throw new OpenXmlTemplateException("Template must be a paragraph, run, table row or table cell");
             }
+
+            // Re-import parts referenced by the inserted content (images, external links) from the source
+            // document into the target part, remapping relationship ids so they resolve. Without this the
+            // clones keep the source's relationship ids and the referenced media is lost.
+            if (loaded.SourcePart != null && targetPart != null)
+            {
+                ImportReferencedParts(loaded.SourcePart, targetPart, insertedElements);
+            }
+
             target.RemoveWithEmptyParent();
         }
 
-        private static OpenXmlCompositeElement LoadTemplateElements(string templateVariable, IModelLookup modelLookup)
+        // Copies parts referenced by the inserted elements (via r:embed / r:id / r:link) from the source part
+        // into the target part and rewrites the relationship ids on the clones so they resolve in the target.
+        private static void ImportReferencedParts(OpenXmlPart source, OpenXmlPart target, List<OpenXmlElement> insertedElements)
+        {
+            var idMap = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var root in insertedElements)
+            {
+                foreach (var element in SelfAndDescendants(root))
+                {
+                    foreach (var attribute in element.GetAttributes())
+                    {
+                        if (attribute.NamespaceUri != RelationshipNamespace || string.IsNullOrEmpty(attribute.Value))
+                        {
+                            continue;
+                        }
+                        if (!idMap.TryGetValue(attribute.Value, out var newId))
+                        {
+                            newId = CopyRelationship(source, target, attribute.Value);
+                            if (newId == null)
+                            {
+                                continue; // unresolved / unsupported relationship type - leave unchanged
+                            }
+                            idMap[attribute.Value] = newId;
+                        }
+                        element.SetAttribute(new OpenXmlAttribute(attribute.Prefix, attribute.LocalName, attribute.NamespaceUri, newId));
+                    }
+                }
+            }
+        }
+
+        private static string CopyRelationship(OpenXmlPart source, OpenXmlPart target, string relationshipId)
+        {
+            // Resolve the id against the source part's relationships without relying on GetPartById throwing.
+            OpenXmlPart sourcePart = null;
+            foreach (var pair in source.Parts)
+            {
+                if (pair.RelationshipId == relationshipId)
+                {
+                    sourcePart = pair.OpenXmlPart;
+                    break;
+                }
+            }
+
+            if (sourcePart is ImagePart image)
+            {
+                var newImage = AddImagePart(target, image.ContentType);
+                if (newImage == null)
+                {
+                    return null; // target part type cannot hold an image - leave the reference unchanged
+                }
+                using var stream = image.GetStream();
+                newImage.FeedData(stream);
+                return target.GetIdOfPart(newImage);
+            }
+
+            var hyperlink = source.HyperlinkRelationships.FirstOrDefault(r => r.Id == relationshipId);
+            if (hyperlink != null)
+            {
+                return target.AddHyperlinkRelationship(hyperlink.Uri, hyperlink.IsExternal).Id;
+            }
+
+            var external = source.ExternalRelationships.FirstOrDefault(r => r.Id == relationshipId);
+            if (external != null)
+            {
+                return target.AddExternalRelationship(external.RelationshipType, external.Uri).Id;
+            }
+
+            // Other embedded part types (OLE objects, charts, ...) are not copied here.
+            return null;
+        }
+
+        private static ImagePart AddImagePart(OpenXmlPart target, string contentType)
+        {
+            return target switch
+            {
+                MainDocumentPart m => m.AddImagePart(contentType),
+                HeaderPart h => h.AddImagePart(contentType),
+                FooterPart f => f.AddImagePart(contentType),
+                _ => null
+            };
+        }
+
+        private static IEnumerable<OpenXmlElement> SelfAndDescendants(OpenXmlElement element)
+        {
+            yield return element;
+            foreach (var descendant in element.Descendants())
+            {
+                yield return descendant;
+            }
+        }
+
+        private static LoadedTemplate LoadTemplateElements(string templateVariable, IModelLookup modelLookup)
         {
             var value = modelLookup.GetValue(templateVariable);
             if (value is string templateString)
@@ -114,7 +231,7 @@ namespace DocxTemplater.Formatter
 
                     if (templateNode is Paragraph paragraph)
                     {
-                        return paragraph;
+                        return new LoadedTemplate(paragraph, null, null);
                     }
                     throw new OpenXmlTemplateException("String template must be a paragraph or run or text");
                 }
@@ -126,35 +243,83 @@ namespace DocxTemplater.Formatter
 
             if (value is OpenXmlCompositeElement templateElement)
             {
-                return templateElement;
+                return new LoadedTemplate(templateElement, null, null);
             }
             if (value is byte[] byteArray)
             {
-                using var memStream = new MemoryStream(byteArray);
-                return OpenXmlElementsFromDocumentStream(memStream);
+                var memStream = new MemoryStream(byteArray);
+                return OpenFromDocumentStream(memStream, ownsStream: true);
             }
 
             if (value is Stream stream)
             {
-                return OpenXmlElementsFromDocumentStream(stream);
+                return OpenFromDocumentStream(stream, ownsStream: false);
             }
             throw new OpenXmlTemplateException("Template must be a string, OpenXmlElement, byte[] or Stream");
         }
 
-        private static OpenXmlCompositeElement OpenXmlElementsFromDocumentStream(Stream stream)
+        // The source document is kept open (returned via LoadedTemplate.Source) so its parts remain readable
+        // while ImportReferencedParts copies them into the target; it is disposed by ApplyFormat.
+        private static LoadedTemplate OpenFromDocumentStream(Stream stream, bool ownsStream)
         {
             stream.Seek(0, SeekOrigin.Begin);
-            using var doc = WordprocessingDocument.Open(stream, false);
-            if (doc.MainDocumentPart == null)
+            WordprocessingDocument doc;
+            try
             {
-                return null;
+                doc = WordprocessingDocument.Open(stream, false);
             }
-            var body = doc.MainDocumentPart.Document.Body;
-            if (body != null)
+            catch
             {
-                return body;
+                if (ownsStream)
+                {
+                    stream.Dispose();
+                }
+                throw;
             }
-            return null;
+            var body = doc.MainDocumentPart?.Document?.Body;
+            if (body == null)
+            {
+                doc.Dispose();
+                if (ownsStream)
+                {
+                    stream.Dispose();
+                }
+                return default;
+            }
+            IDisposable disposer = ownsStream ? new CompositeDisposable(doc, stream) : doc;
+            return new LoadedTemplate(body, doc.MainDocumentPart, disposer);
+        }
+
+        private readonly struct LoadedTemplate
+        {
+            public LoadedTemplate(OpenXmlCompositeElement element, OpenXmlPart sourcePart, IDisposable source)
+            {
+                Element = element;
+                SourcePart = sourcePart;
+                Source = source;
+            }
+
+            public OpenXmlCompositeElement Element { get; }
+            public OpenXmlPart SourcePart { get; }
+            public IDisposable Source { get; }
+        }
+
+        private sealed class CompositeDisposable : IDisposable
+        {
+            private readonly IDisposable[] _items;
+
+            public CompositeDisposable(params IDisposable[] items)
+            {
+                _items = items;
+            }
+
+            public void Dispose()
+            {
+                foreach (var item in _items)
+                {
+                    item?.Dispose();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The `:template` / `:T` formatter clones the inserted document's body into the target document, but it never copied the parts those clones reference. Image relationship ids (`a:blip/@r:embed`) therefore pointed at the source document's relationships, which do not exist in the target, so the `r:embed` dangled and the image was lost.

Keep the source document open for the duration of the merge and, after the content is cloned, re-import the referenced parts into the target part and remap the relationship ids on the inserted clones:

- images (`ImagePart`) are copied via `AddImagePart` + `FeedData`;
- hyperlinks and other external relationships are re-created on the target;
- unsupported/embedded part types (OLE, charts) are left unchanged.

Adds a regression test (`SubTemplateImageImportTest`) that inserts a document containing an embedded image and asserts the merged document has a resolvable image part whose bytes match the source image, for both byte[] and Stream bindings.