### PR TITLE
Fill Word content controls from the model by their tag

### DIFF
--- a/DocxTemplater.Test/ContentControlBindingTest.cs
+++ b/DocxTemplater.Test/ContentControlBindingTest.cs
@@ -180,8 +180,63 @@ namespace DocxTemplater.Test
                   <w:sdtContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:sdtContent>
                 </w:sdt>";
 
-            using var template = new DocxTemplate(CreateTemplate(body));
+            using var template = new DocxTemplate(CreateTemplate(body),
+                new ProcessSettings { EnableContentControlTagBinding = true });
             template.BindModel("ds", new { Name = "World" });
+
+            Assert.Throws<OpenXmlTemplateException>(() => template.Process());
+        }
+
+        [Test]
+        public void PlaceholderTag_IsIgnored_WhenFlagDisabled()
+        {
+            // With the opt-in flag off (the default), a placeholder tag must be left completely alone -
+            // no fill, no content change, no placeholder-flag removal.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Name}}""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>placeholder</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            MemoryStream result;
+            using (var template = new DocxTemplate(CreateTemplate(body))) // default settings -> flag OFF
+            {
+                template.BindModel("ds", new { Name = "World" });
+                var processed = template.Process();
+                result = new MemoryStream();
+                processed.Position = 0;
+                processed.CopyTo(result);
+                result.Position = 0;
+            }
+
+            using var doc = WordprocessingDocument.Open(result, false);
+            var control = ContentControl(doc.MainDocumentPart.Document.Body, "{{ds.Name}}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(control.InnerText, Is.EqualTo("placeholder"), "the feature is inert when the flag is off");
+                Assert.That(control.SdtProperties.GetFirstChild<ShowingPlaceholder>(), Is.Not.Null,
+                    "the placeholder flag is left in place when the flag is off");
+            });
+        }
+
+        [Test]
+        public void ResolvedValue_WithNoTextTarget_IsSurfaced()
+        {
+            // An empty cell/row content control has nowhere to put a resolved value. Under ThrowException
+            // that must surface as an error, not be silently dropped.
+            const string body = @"
+                <w:tbl xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:tr>
+                    <w:sdt>
+                      <w:sdtPr><w:tag w:val=""{{ds.X}}""/></w:sdtPr>
+                      <w:sdtContent><w:tc><w:tcPr><w:tcW w:w=""5000"" w:type=""dxa""/></w:tcPr><w:p/></w:tc></w:sdtContent>
+                    </w:sdt>
+                  </w:tr>
+                </w:tbl>";
+
+            using var template = new DocxTemplate(CreateTemplate(body),
+                new ProcessSettings { EnableContentControlTagBinding = true });
+            template.BindModel("ds", new { X = "value" });
 
             Assert.Throws<OpenXmlTemplateException>(() => template.Process());
         }
@@ -443,6 +498,9 @@ namespace DocxTemplater.Test
 
         private static MemoryStream RenderStream(Stream template, ProcessSettings settings, Action<DocxTemplate> bind)
         {
+            // This fixture exercises the feature, so binding is enabled for all render helpers. The
+            // flag-off behaviour is covered separately by PlaceholderTag_IsIgnored_WhenFlagDisabled.
+            settings.EnableContentControlTagBinding = true;
             using var docTemplate = new DocxTemplate(template, settings);
             bind(docTemplate);
             var processed = docTemplate.Process();

--- a/DocxTemplater.Test/ContentControlBindingTest.cs
+++ b/DocxTemplater.Test/ContentControlBindingTest.cs
@@ -1,0 +1,474 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocxTemplater.Test
+{
+    /// <summary>
+    /// Binding of Word content controls (structured document tags) by a placeholder in their tag.
+    /// A content control whose <c>w:tag</c> is a placeholder (e.g. <c>{{ds.Name}}</c>) has its content
+    /// filled from the bound model, while the control itself and its tag are preserved so it can be
+    /// filled again in a later pass.
+    /// </summary>
+    internal class ContentControlBindingTest
+    {
+        [Test]
+        public void BlockContentControl_WithPlaceholderTag_IsFilledFromModel()
+        {
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Name}}""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>Click here to enter text.</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = "World" }));
+
+            var control = ContentControl(result, "{{ds.Name}}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(control.InnerText, Is.EqualTo("World"), "content is filled from the model");
+                Assert.That(Tag(control), Is.EqualTo("{{ds.Name}}"), "the tag is preserved so the control stays addressable");
+                Assert.That(control.SdtProperties.GetFirstChild<ShowingPlaceholder>(), Is.Null,
+                    "the 'showing placeholder' flag is cleared so Word treats the value as real text");
+            });
+        }
+
+        [Test]
+        public void ContentControlTag_AppliesFormatter()
+        {
+            // The same formatter pipeline as text placeholders is reused, so any formatter works.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Name}:ToUpper()}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = "world" }));
+
+            Assert.That(ContentControl(result, "{{ds.Name}:ToUpper()}").InnerText, Is.EqualTo("WORLD"));
+        }
+
+        [Test]
+        public void InlineRunContentControl_IsFilled()
+        {
+            const string body = @"
+                <w:p xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:r><w:t xml:space=""preserve"">Reference: </w:t></w:r>
+                  <w:sdt>
+                    <w:sdtPr><w:tag w:val=""{{ds.Ref}}""/></w:sdtPr>
+                    <w:sdtContent><w:r><w:t>placeholder</w:t></w:r></w:sdtContent>
+                  </w:sdt>
+                </w:p>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Ref = "R-42" }));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ContentControl(result, "{{ds.Ref}}").InnerText, Is.EqualTo("R-42"));
+                Assert.That(result.InnerText, Is.EqualTo("Reference: R-42"));
+            });
+        }
+
+        [Test]
+        public void NonPlaceholderTag_IsLeftUnchanged()
+        {
+            // A content control with an ordinary (non-placeholder) tag must be ignored entirely,
+            // so existing templates are unaffected.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""JustATag""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>original text</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = "World" }));
+
+            var control = ContentControl(result, "JustATag");
+            Assert.Multiple(() =>
+            {
+                Assert.That(control.InnerText, Is.EqualTo("original text"), "content is untouched");
+                Assert.That(control.SdtProperties.GetFirstChild<ShowingPlaceholder>(), Is.Not.Null,
+                    "the placeholder flag is untouched");
+            });
+        }
+
+        [Test]
+        public void PlaceholderInsideContentControlContent_StillWorks_WithPlainTag()
+        {
+            // Regression: a placeholder placed in the *content* of a control with a plain tag keeps working
+            // through the normal text pass (this is unchanged, pre-existing behaviour).
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""PlainTag""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>Hello {{ds.Name}}</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = "World" }));
+
+            Assert.That(ContentControl(result, "PlainTag").InnerText, Is.EqualTo("Hello World"));
+        }
+
+        [Test]
+        public void UnboundTag_IsLeftUntouched_AndSecondPassFillsIt_WithoutClearingTheFirstPass()
+        {
+            // The deferred / multi-pass scenario: a document is generated (pass 1 fills what it can) and a
+            // content control is filled later (pass 2), e.g. stamping a delivery date after review.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Reference}}""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>ref placeholder</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.DeliveryDate}}""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>date placeholder</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            // Pass 1: only Reference is bound. DeliveryDate is unbound and must be left completely intact.
+            var afterPass1 = RenderStream(CreateTemplate(body), Skip, t => t.BindModel("ds", new { Reference = "R-42" }));
+            using (var doc1 = WordprocessingDocument.Open(CopyOf(afterPass1), false))
+            {
+                var b1 = doc1.MainDocumentPart.Document.Body;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ContentControl(b1, "{{ds.Reference}}").InnerText, Is.EqualTo("R-42"), "Reference filled in pass 1");
+                    var delivery = ContentControl(b1, "{{ds.DeliveryDate}}");
+                    Assert.That(delivery.InnerText, Is.EqualTo("date placeholder"), "unbound control content is left untouched");
+                    Assert.That(delivery.SdtProperties.GetFirstChild<ShowingPlaceholder>(), Is.Not.Null,
+                        "unbound control keeps its placeholder flag for a later pass");
+                });
+            }
+
+            // Pass 2: only DeliveryDate is bound. It must be filled WITHOUT clearing the value pass 1 wrote.
+            var afterPass2 = RenderStream(afterPass1, Skip, t => t.BindModel("ds", new { DeliveryDate = "8 Jul 2026" }));
+            using var doc2 = WordprocessingDocument.Open(afterPass2, false);
+            var b2 = doc2.MainDocumentPart.Document.Body;
+            Assert.Multiple(() =>
+            {
+                Assert.That(ContentControl(b2, "{{ds.DeliveryDate}}").InnerText, Is.EqualTo("8 Jul 2026"), "DeliveryDate filled in pass 2");
+                Assert.That(ContentControl(b2, "{{ds.Reference}}").InnerText, Is.EqualTo("R-42"),
+                    "the value written in pass 1 is NOT cleared by pass 2");
+            });
+        }
+
+        [Test]
+        public void ContentControlInLoop_IsFilledPerIteration()
+        {
+            const string body = @"
+                <w:p xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main""><w:r><w:t>{{#ds.Items}}</w:t></w:r></w:p>
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Items}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>item</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>
+                <w:p xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main""><w:r><w:t>{{/ds.Items}}</w:t></w:r></w:p>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Items = new[] { "a", "b", "c" } }));
+
+            var controls = result.Descendants<SdtElement>().Where(c => Tag(c) == "{{ds.Items}}").ToList();
+            string[] expected = ["a", "b", "c"];
+            Assert.Multiple(() =>
+            {
+                Assert.That(controls, Has.Count.EqualTo(3), "one content control per loop item");
+                Assert.That(controls.Select(c => c.InnerText).ToArray(), Is.EqualTo(expected));
+            });
+        }
+
+        [Test]
+        public void UnboundTag_ThrowsByDefault()
+        {
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Missing}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            using var template = new DocxTemplate(CreateTemplate(body));
+            template.BindModel("ds", new { Name = "World" });
+
+            Assert.Throws<OpenXmlTemplateException>(() => template.Process());
+        }
+
+        [Test]
+        public void HighlightErrorsMode_MarksUnboundContentControl()
+        {
+            const string body = @"
+                <w:p xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main""><w:r><w:t>Intro</w:t></w:r></w:p>
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Missing}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var settings = new ProcessSettings { BindingErrorHandling = BindingErrorHandling.HighlightErrorsInDocument };
+            var result = RenderStream(CreateTemplate(body), settings, t => t.BindModel("ds", new { Name = "World" }));
+
+            using var doc = WordprocessingDocument.Open(result, false);
+            var control = ContentControl(doc.MainDocumentPart.Document.Body, "{{ds.Missing}}");
+            var shading = control.Descendants<Shading>().FirstOrDefault();
+            Assert.Multiple(() =>
+            {
+                Assert.That(shading?.Fill?.Value, Is.EqualTo("FF0000"), "the unbound control content is highlighted as an error");
+                Assert.That(control.InnerText, Is.EqualTo("x"), "the original content is highlighted in place, not cleared");
+            });
+        }
+
+        [Test]
+        public void MalformedPlaceholderTag_IsIgnored_AndDoesNotThrow()
+        {
+            // A tag that contains braces but is not a valid value binding (a malformed/block directive) must
+            // be left alone, not abort the render - even in the default ThrowException mode.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>keep-a</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{/switch}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>keep-b</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = "World" }));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ContentControl(result, "{{}}").InnerText, Is.EqualTo("keep-a"));
+                Assert.That(ContentControl(result, "{{/switch}}").InnerText, Is.EqualTo("keep-b"));
+            });
+        }
+
+        [Test]
+        public void NullValue_LeavesControlUntouched()
+        {
+            // A bound-but-null value is treated like an unbound tag: the control is left unchanged (so a
+            // shared model type carrying null members never wipes a control).
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Name}}""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>placeholder</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = (string)null }));
+
+            var control = ContentControl(result, "{{ds.Name}}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(control.InnerText, Is.EqualTo("placeholder"), "null value leaves the content untouched");
+                Assert.That(control.SdtProperties.GetFirstChild<ShowingPlaceholder>(), Is.Not.Null,
+                    "null value leaves the placeholder flag in place");
+            });
+        }
+
+        [Test]
+        public void MultiPass_WithSharedModelType_DoesNotClearAnEarlierPass()
+        {
+            // Same guarantee as the anonymous-type deferred test, but with a shared DTO whose other member is
+            // null (not absent) in each pass - which must NOT clear the value written by the previous pass.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Reference}}""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>ref</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.DeliveryDate}}""/><w:showingPlcHdr/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>date</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var pass1 = RenderStream(CreateTemplate(body), ProcessSettings.Default,
+                t => t.BindModel("ds", new TwoFields { Reference = "R-42" }));
+            var pass2 = RenderStream(pass1, ProcessSettings.Default,
+                t => t.BindModel("ds", new TwoFields { DeliveryDate = "8 Jul 2026" }));
+
+            using var doc = WordprocessingDocument.Open(pass2, false);
+            var b = doc.MainDocumentPart.Document.Body;
+            Assert.Multiple(() =>
+            {
+                Assert.That(ContentControl(b, "{{ds.DeliveryDate}}").InnerText, Is.EqualTo("8 Jul 2026"));
+                Assert.That(ContentControl(b, "{{ds.Reference}}").InnerText, Is.EqualTo("R-42"),
+                    "pass 1's value survives pass 2 even though ds.Reference is null in pass 2");
+            });
+        }
+
+        [Test]
+        public void MultiParagraphControl_CollapsesToSingleValue_NoStrayParagraph()
+        {
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Name}}""/></w:sdtPr>
+                  <w:sdtContent>
+                    <w:p><w:r><w:rPr><w:b/></w:rPr><w:t>line1</w:t></w:r></w:p>
+                    <w:p><w:r><w:t>line2</w:t></w:r></w:p>
+                  </w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = "World" }));
+
+            var control = ContentControl(result, "{{ds.Name}}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(control.InnerText, Is.EqualTo("World"));
+                Assert.That(control.Descendants<Paragraph>().Count(), Is.EqualTo(1), "no stray empty paragraph is left behind");
+                Assert.That(control.Descendants<Bold>().Any(), Is.True, "the first run's formatting is preserved");
+            });
+        }
+
+        [Test]
+        public void NestedContentControl_OuterDoesNotCorruptInner()
+        {
+            // An outer bound control whose content also contains an inner (plain-tag) control must fill its
+            // OWN text without touching the inner control's content.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Outer}}""/></w:sdtPr>
+                  <w:sdtContent>
+                    <w:p>
+                      <w:r><w:t xml:space=""preserve"">own </w:t></w:r>
+                      <w:sdt>
+                        <w:sdtPr><w:tag w:val=""InnerPlain""/></w:sdtPr>
+                        <w:sdtContent><w:r><w:t>KEEP</w:t></w:r></w:sdtContent>
+                      </w:sdt>
+                    </w:p>
+                  </w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Outer = "OUTERVAL" }));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ContentControl(result, "InnerPlain").InnerText, Is.EqualTo("KEEP"),
+                    "the inner control's content is not consumed by the outer fill");
+                Assert.That(result.InnerText, Does.Contain("OUTERVAL"), "the outer control is still filled with its own value");
+            });
+        }
+
+        [Test]
+        public void ExpressionTag_IsEvaluated()
+        {
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{(ds.A + ds.B)}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { A = 2, B = 3 }));
+
+            Assert.That(ContentControl(result, "{{(ds.A + ds.B)}}").InnerText, Is.EqualTo("5"));
+        }
+
+        [Test]
+        public void PlaceholderInTagAndContent_TagWins()
+        {
+            // Tag is a placeholder AND the content starts with a placeholder: the tag drives the fill and the
+            // content placeholder is discarded without leaving a marker for the text pass to choke on.
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.A}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>{{ds.B}}</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { A = "AVAL", B = "BVAL" }));
+
+            Assert.That(ContentControl(result, "{{ds.A}}").InnerText, Is.EqualTo("AVAL"));
+        }
+
+        [Test]
+        public void EmptyContentControl_IsFilled()
+        {
+            const string body = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Name}}""/></w:sdtPr>
+                  <w:sdtContent><w:p/></w:sdtContent>
+                </w:sdt>";
+
+            var result = Render(body, t => t.BindModel("ds", new { Name = "World" }));
+
+            Assert.That(ContentControl(result, "{{ds.Name}}").InnerText, Is.EqualTo("World"));
+        }
+
+        [Test]
+        public void ContentControlInHeader_IsFilled()
+        {
+            const string sdt = @"
+                <w:sdt xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+                  <w:sdtPr><w:tag w:val=""{{ds.Name}}""/></w:sdtPr>
+                  <w:sdtContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:sdtContent>
+                </w:sdt>";
+
+            var template = new MemoryStream();
+            using (var wpDocument = WordprocessingDocument.Create(template, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+            {
+                var mainPart = wpDocument.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body(new Paragraph()));
+                var headerPart = mainPart.AddNewPart<HeaderPart>();
+                headerPart.Header = new Header { InnerXml = sdt };
+                wpDocument.Save();
+            }
+            template.Position = 0;
+
+            var result = RenderStream(template, ProcessSettings.Default, t => t.BindModel("ds", new { Name = "World" }));
+
+            using var doc = WordprocessingDocument.Open(result, false);
+            var header = doc.MainDocumentPart.HeaderParts.First().Header;
+            Assert.That(ContentControl(header, "{{ds.Name}}").InnerText, Is.EqualTo("World"));
+        }
+
+        // ---- helpers -------------------------------------------------------------------------------------
+
+        // A model type shared across passes whose non-bound member is null (not absent) in each pass.
+        private sealed class TwoFields
+        {
+            public string Reference { get; set; }
+            public string DeliveryDate { get; set; }
+        }
+
+        private static readonly ProcessSettings Skip =
+            new() { BindingErrorHandling = BindingErrorHandling.SkipBindingAndRemoveContent };
+
+        private static MemoryStream CreateTemplate(string bodyInnerXml)
+        {
+            var memStream = new MemoryStream();
+            using (var wpDocument = WordprocessingDocument.Create(memStream, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+            {
+                var mainPart = wpDocument.AddMainDocumentPart();
+                mainPart.Document = new Document { Body = new Body { InnerXml = bodyInnerXml } };
+                wpDocument.Save();
+            }
+            memStream.Position = 0;
+            return memStream;
+        }
+
+        private static Body Render(string bodyInnerXml, Action<DocxTemplate> bind)
+        {
+            var result = RenderStream(CreateTemplate(bodyInnerXml), ProcessSettings.Default, bind);
+            using var doc = WordprocessingDocument.Open(result, false);
+            // clone the body so it stays usable after the document is disposed
+            return (Body)doc.MainDocumentPart.Document.Body.CloneNode(true);
+        }
+
+        private static MemoryStream RenderStream(Stream template, ProcessSettings settings, Action<DocxTemplate> bind)
+        {
+            using var docTemplate = new DocxTemplate(template, settings);
+            bind(docTemplate);
+            var processed = docTemplate.Process();
+            docTemplate.Validate();
+            var copy = new MemoryStream();
+            processed.Position = 0;
+            processed.CopyTo(copy);
+            copy.Position = 0;
+            return copy;
+        }
+
+        private static MemoryStream CopyOf(MemoryStream source)
+        {
+            var copy = new MemoryStream(source.ToArray()) { Position = 0 };
+            source.Position = 0;
+            return copy;
+        }
+
+        private static SdtElement ContentControl(OpenXmlElement root, string tag)
+        {
+            return root.Descendants<SdtElement>().Single(c => Tag(c) == tag);
+        }
+
+        private static string Tag(SdtElement contentControl)
+        {
+            return contentControl.SdtProperties?.GetFirstChild<Tag>()?.Val?.Value;
+        }
+    }
+}

--- a/DocxTemplater/Formatter/VariableReplacer.cs
+++ b/DocxTemplater/Formatter/VariableReplacer.cs
@@ -203,6 +203,13 @@ namespace DocxTemplater.Formatter
         /// </remarks>
         private void ReplaceContentControlValues(OpenXmlElement root, ITemplateProcessingContext templateContext)
         {
+            // Opt-in: content-control tag binding inspects the w:tag of pre-existing controls, which could
+            // change behavior of templates not authored for DocxTemplater. It is off unless explicitly enabled.
+            if (!ProcessSettings.EnableContentControlTagBinding)
+            {
+                return;
+            }
+
             var contentControls = root.Descendants<SdtElement>().ToList();
             if (root is SdtElement rootControl)
             {
@@ -270,6 +277,11 @@ namespace DocxTemplater.Formatter
             var target = PrepareContentControlTarget(contentControl);
             if (target == null)
             {
+                // The value resolved but there is nowhere to put it (e.g. an empty cell/row content control).
+                // Surface this per the error mode instead of silently dropping the resolved value.
+                ApplyContentControlErrorMode(contentControl, tag,
+                    new OpenXmlTemplateException("the resolved value has no text run to fill (empty cell/row content controls are not supported)"),
+                    preparedTarget: null);
                 return;
             }
 

--- a/DocxTemplater/Formatter/VariableReplacer.cs
+++ b/DocxTemplater/Formatter/VariableReplacer.cs
@@ -142,6 +142,12 @@ namespace DocxTemplater.Formatter
 
         public void ReplaceVariables(OpenXmlElement cloned, ITemplateProcessingContext templateContext)
         {
+            // Fill content controls (structured document tags) whose tag is a placeholder, before the
+            // text-placeholder pass. Runs from the same choke point so it applies to the root element and,
+            // because loop bodies are rendered by cloning their content and calling this method again, to
+            // every loop iteration as well.
+            ReplaceContentControlValues(cloned, templateContext);
+
             var variables = cloned.GetElementsWithMarker(PatternType.Variable)
                 .Concat(cloned.GetElementsWithMarker(PatternType.Expression))
                 .OfType<Text>().ToList();
@@ -180,6 +186,217 @@ namespace DocxTemplater.Formatter
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Fills Word content controls (structured document tags) whose <c>w:tag</c> is a DocxTemplater
+        /// placeholder (e.g. a tag of <c>{{ds.Name}}</c> or <c>{{ds.Price}:f(c)}</c>). The resolved model
+        /// value replaces the control's content using the same model lookup and formatters as text
+        /// placeholders, and the "showing placeholder" flag is cleared so Word treats the value as real text.
+        /// </summary>
+        /// <remarks>
+        /// Unlike a text placeholder, a content control is a named, persistent region: it is never removed,
+        /// and its tag is left untouched, so the control keeps its identity and can be filled again in a
+        /// later processing pass (e.g. stamping a delivery date after the document was generated and reviewed).
+        /// Tags that are not a placeholder - or whose placeholder is a block directive such as
+        /// <c>{{#items}}</c> - are ignored, so existing templates are unaffected.
+        /// </remarks>
+        private void ReplaceContentControlValues(OpenXmlElement root, ITemplateProcessingContext templateContext)
+        {
+            var contentControls = root.Descendants<SdtElement>().ToList();
+            if (root is SdtElement rootControl)
+            {
+                contentControls.Insert(0, rootControl);
+            }
+
+            foreach (var contentControl in contentControls)
+            {
+                var tag = contentControl.SdtProperties?.GetFirstChild<Tag>()?.Val?.Value;
+                if (string.IsNullOrEmpty(tag) || !tag.Contains("{{"))
+                {
+                    continue;
+                }
+
+                PatternMatch match;
+                try
+                {
+                    match = PatternMatcher.FindSyntaxPatterns(tag).FirstOrDefault();
+                }
+                catch (OpenXmlTemplateException)
+                {
+                    // The tag contains braces but is a malformed directive (e.g. "{{@}}" or "{{/switch}}"),
+                    // not a value binding. Treat it like any non-placeholder tag and leave the control
+                    // untouched, rather than letting the parse error abort the whole render.
+                    continue;
+                }
+
+                if (match == null || (match.Type != PatternType.Variable && match.Type != PatternType.Expression))
+                {
+                    continue;
+                }
+
+                FillContentControl(contentControl, tag, match, templateContext);
+            }
+        }
+
+        private void FillContentControl(SdtElement contentControl, string tag, PatternMatch match, ITemplateProcessingContext templateContext)
+        {
+            // Resolve the value BEFORE touching the control's content. If the tag cannot be bound, the
+            // control is left exactly as it was - see ApplyContentControlErrorMode. This is what makes
+            // multi-pass filling safe: a later pass that does not bind this tag must not clear a value a
+            // previous pass wrote.
+            object value;
+            try
+            {
+                value = match.Type == PatternType.Expression
+                    ? templateContext.ScriptCompiler.CompileExpression(match.Variable)()
+                    : m_models.GetValueWithMetadata(match.Variable);
+            }
+            catch (Exception e) when (e is OpenXmlTemplateException or FormatException)
+            {
+                ApplyContentControlErrorMode(contentControl, tag, e, preparedTarget: null);
+                return;
+            }
+
+            // A resolved-but-null value (a bound member that is simply null, as opposed to an absent one
+            // that throws above) is treated like an unbound tag: the control is left untouched. This keeps
+            // multi-pass filling non-destructive when passes share a model type whose other members are null.
+            var resolvedValue = match.Type == PatternType.Expression ? value : ((ValueWithMetadata)value).Value;
+            if (resolvedValue == null)
+            {
+                return;
+            }
+
+            var target = PrepareContentControlTarget(contentControl);
+            if (target == null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (match.Type == PatternType.Expression)
+                {
+                    ApplyFormatter(match, value, target, templateContext);
+                }
+                else
+                {
+                    ApplyFormatter(templateContext, match, (ValueWithMetadata)value, target);
+                }
+                SplitNewLinesInText(target);
+            }
+            catch (Exception e) when (e is OpenXmlTemplateException or FormatException)
+            {
+                ApplyContentControlErrorMode(contentControl, tag, e, target);
+                return;
+            }
+
+            RemoveShowingPlaceholder(contentControl);
+        }
+
+        /// <summary>
+        /// Applies the configured <see cref="BindingErrorHandling"/> to a content control whose tag could
+        /// not be resolved or formatted, without ever removing the control itself.
+        /// <paramref name="preparedTarget"/> is <c>null</c> when the failure happened before the content was
+        /// touched (value resolution): in that case the control is left completely unchanged under
+        /// <see cref="BindingErrorHandling.SkipBindingAndRemoveContent"/>.
+        /// </summary>
+        private void ApplyContentControlErrorMode(SdtElement contentControl, string tag, Exception e, Text preparedTarget)
+        {
+            switch (ProcessSettings.BindingErrorHandling)
+            {
+                case BindingErrorHandling.SkipBindingAndRemoveContent:
+                    if (preparedTarget is { } clearedTarget)
+                    {
+                        clearedTarget.Text = string.Empty;
+                    }
+                    break;
+                case BindingErrorHandling.HighlightErrorsInDocument:
+                    // For a resolution failure (no prepared target) highlight the control's existing content
+                    // in place WITHOUT clearing it, so the marker is visible and the original text is kept,
+                    // mirroring how a text placeholder is highlighted. For a formatting failure the target is
+                    // already prepared.
+                    var target = preparedTarget ?? FirstOwnText(contentControl);
+                    if (target != null)
+                    {
+                        MarkTextAsError(target);
+                    }
+                    AddError(e.Message);
+                    break;
+                default:
+                    throw new OpenXmlTemplateException($"Content control tag '{tag}' could not be replaced: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// Reduces the content control's own content to a single, empty, unmarked <see cref="Text"/> that
+        /// the formatter pipeline can write into. The first existing text run is reused (so its formatting
+        /// is kept); any further text runs - and the now-empty runs/paragraphs around them - are dropped, so
+        /// no blank lines are left behind. Text belonging to a nested content control is never touched. An
+        /// empty inline/block control gets a minimal run so there is something to fill. Returns <c>null</c>
+        /// when the control has no place to put text (e.g. an empty cell/row control), leaving it untouched.
+        /// </summary>
+        private static Text PrepareContentControlTarget(SdtElement contentControl)
+        {
+            var content = contentControl.ChildElements
+                .FirstOrDefault(c => c is SdtContentBlock or SdtContentRun or SdtContentCell or SdtContentRow);
+            if (content == null)
+            {
+                return null;
+            }
+
+            var texts = OwnTexts(contentControl, content);
+            if (texts.Count > 0)
+            {
+                var target = texts[0];
+                for (var i = 1; i < texts.Count; i++)
+                {
+                    texts[i].RemoveWithEmptyParent();
+                }
+                // Drop a marker left by the isolate pass if the control's placeholder text happened to
+                // contain '{{...}}', so the text-placeholder pass does not process (and possibly remove) it.
+                target.RemoveMarker();
+                target.Text = string.Empty;
+                target.Space = SpaceProcessingModeValues.Preserve;
+                return target;
+            }
+
+            var newText = new Text { Space = SpaceProcessingModeValues.Preserve };
+            if (content is SdtContentRun)
+            {
+                content.AppendChild(new Run(newText));
+                return newText;
+            }
+            if (content is SdtContentBlock)
+            {
+                content.AppendChild(new Paragraph(new Run(newText)));
+                return newText;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The <see cref="Text"/> nodes that belong directly to this content control - i.e. not to a
+        /// content control nested inside it. Scoping to the control's own text keeps an outer control from
+        /// consuming or corrupting the content of an inner one.
+        /// </summary>
+        private static List<Text> OwnTexts(SdtElement contentControl, OpenXmlElement content)
+        {
+            return content.Descendants<Text>()
+                .Where(t => t.Ancestors<SdtElement>().FirstOrDefault() == contentControl)
+                .ToList();
+        }
+
+        private static Text FirstOwnText(SdtElement contentControl)
+        {
+            var content = contentControl.ChildElements
+                .FirstOrDefault(c => c is SdtContentBlock or SdtContentRun or SdtContentCell or SdtContentRow);
+            return content == null ? null : OwnTexts(contentControl, content).FirstOrDefault();
+        }
+
+        private static void RemoveShowingPlaceholder(SdtElement contentControl)
+        {
+            contentControl.SdtProperties?.GetFirstChild<ShowingPlaceholder>()?.Remove();
         }
 
         /// <summary>

--- a/DocxTemplater/ProcessSettings.cs
+++ b/DocxTemplater/ProcessSettings.cs
@@ -13,11 +13,17 @@ namespace DocxTemplater
         public BindingErrorHandling BindingErrorHandling { get; set; } = BindingErrorHandling.ThrowException;
 
         /// <summary>
-        /// When enabled, this option removes leading or trailing newlines around template directives (e.g., {{#...}}, {{/}}) 
+        /// When enabled, this option removes leading or trailing newlines around template directives (e.g., {{#...}}, {{/}})
         /// from the final output. This allows templates to be more readable without affecting rendered formatting.
         /// default: false
         /// </summary>
         public bool IgnoreLineBreaksAroundTags { get; set; }
+
+        /// <summary>
+        /// When enabled, content controls whose tag is a placeholder (e.g. {{ds.Name}})
+        /// are filled from the model. Default: false.
+        /// </summary>
+        public bool EnableContentControlTagBinding { get; set; }
 
         public static ProcessSettings Default => new();
     }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ _DocxTemplater is a library to generate docx documents from a docx template. The
 - Markdown Support - Converts Markdown to OpenXML
 - HTML Snippets - Replace placeholder with HTML Content
 - Dynamic Tables - Columns are defined by the datasource
+- Content Controls - Fill Word content controls from the model, addressed by their tag
 - Template Schema - Statically inspect which variables a template expects, without rendering
 
 ## Quickstart
@@ -412,6 +413,49 @@ The value in front of the formatter (here `ds`) is bound as `ds` *inside* the in
 ```
 
 **_NOTE:_** The content is inserted by copying the OpenXML body elements into the host document. Styles, numbering definitions and images stored in the inserted document's own parts are not imported.
+
+---
+## Content Controls
+
+A Word [content control](https://support.microsoft.com/en-us/office/create-a-template-9bc66f57-cbd0-4a2c-be7c-9b839d3a9019) (a *structured document tag*, `w:sdt`) can be filled from the model by putting a placeholder in its **tag**. Set the control's *Tag* (Developer tab → Properties → Tag) to a placeholder such as `{{ds.Name}}`, and DocxTemplater replaces the control's content with the resolved value:
+
+```csharp
+var template = DocxTemplate.Open("template.docx");
+template.BindModel("ds", new { Name = "World", DeliveryDate = new DateTime(2026, 7, 8) });
+template.Save("generated.docx");
+```
+
+| Content control *Tag*                | Result                                              |
+| ------------------------------------ | --------------------------------------------------- |
+| `{{ds.Name}}`                        | Filled with the value of `ds.Name`.                 |
+| `{{ds.Name}:ToUpper()}`              | Formatters work exactly as in text placeholders.    |
+| `{{ds.DeliveryDate}:F('d MMM yyyy')}`| Date/number format strings are supported.           |
+
+The same model lookup and formatters as text placeholders are used, and content controls inside a loop are filled once per iteration (the tag resolves against the loop scope, e.g. `{{ds.Items}}` or `{{.Name}}`). A tag whose value resolves to `null` is treated like an unbound tag (see below).
+
+> [!NOTE]
+> Only formatters that produce **inline text** (e.g. `ToUpper`, `ToLower`, `format`, and C# expressions) are supported on a content control tag. Block-producing formatters (`html`, `md`, `img`, `template`) are not supported inside a content control - use them as normal text placeholders in the document body instead.
+
+Unlike a text placeholder, a content control is a **named, persistent region**:
+
+- The control and its tag are **never removed** and are **preserved** in the output, so the control stays addressable.
+- A control whose tag **cannot be bound** is **left unchanged** (under `SkipBindingAndRemoveContent`). This makes multi-pass filling safe - a control filled in an earlier pass is never cleared by a later pass that does not bind its tag:
+
+```csharp
+// Pass 1: generate the document, binding what is known now.
+var generated = Fill(templateBytes, new { Reference = "R-42" });
+
+// Pass 2 (later): stamp a value into a control that was left empty in pass 1,
+// without disturbing anything pass 1 already filled.
+var finalDoc = Fill(generated, new { DeliveryDate = "8 Jul 2026" });
+```
+
+- The control's "showing placeholder" flag is cleared on a successful fill, so Word shows the value as real text rather than grey placeholder text.
+
+A tag that is not a placeholder - or whose placeholder is a block directive such as `{{#items}}` - is ignored, so existing templates are unaffected. Placeholders in a content control's *content* (rather than its tag) keep working as normal text placeholders.
+
+> [!NOTE]
+> Content control tag bindings are not reported by `GetTemplateSchema()` (the tag is not part of the rendered text). This is the same limitation as sub-template formatters.
 
 ---
 ## Whitespace Trimming Around Directives

--- a/README.md
+++ b/README.md
@@ -417,10 +417,13 @@ The value in front of the formatter (here `ds`) is bound as `ds` *inside* the in
 ---
 ## Content Controls
 
-A Word [content control](https://support.microsoft.com/en-us/office/create-a-template-9bc66f57-cbd0-4a2c-be7c-9b839d3a9019) (a *structured document tag*, `w:sdt`) can be filled from the model by putting a placeholder in its **tag**. Set the control's *Tag* (Developer tab → Properties → Tag) to a placeholder such as `{{ds.Name}}`, and DocxTemplater replaces the control's content with the resolved value:
+A Word [content control](https://support.microsoft.com/en-us/office/create-a-template-9bc66f57-cbd0-4a2c-be7c-9b839d3a9019) (a *structured document tag*, `w:sdt`) can be filled from the model by putting a placeholder in its **tag**. Set the control's *Tag* (Developer tab → Properties → Tag) to a placeholder such as `{{ds.Name}}`, and DocxTemplater replaces the control's content with the resolved value.
+
+This is **opt-in** and off by default (existing templates may contain content-control tags never intended as placeholders). Enable it via `ProcessSettings.EnableContentControlTagBinding`:
 
 ```csharp
-var template = DocxTemplate.Open("template.docx");
+var template = DocxTemplate.Open("template.docx",
+    new ProcessSettings { EnableContentControlTagBinding = true });
 template.BindModel("ds", new { Name = "World", DeliveryDate = new DateTime(2026, 7, 8) });
 template.Save("generated.docx");
 ```


### PR DESCRIPTION
## Summary

Adds support for **binding Word content controls (structured document tags, `w:sdt`) to the model by their tag**. If a content control's *Tag* is a DocxTemplater placeholder — e.g. `{{ds.Name}}` or `{{ds.Price}:f(c)}` — its content is filled with the resolved model value, reusing the existing model lookup and formatter pipeline. The content control itself is preserved, so it stays a named, re-fillable region.

Today the only way to drive a content control is to embed a `{{…}}` placeholder in its *visible content*, which is consumed on the first render and can't model a named region that is filled in a later pass. This lets a content control be addressed by its tag instead.

## Usage

Set a content control's *Tag* (Developer → Properties → Tag) to a placeholder:

| Content control *Tag*                 | Result                                           |
| ------------------------------------- | ------------------------------------------------ |
| `{{ds.Name}}`                         | Filled with the value of `ds.Name`.              |
| `{{ds.Name}:ToUpper()}`               | Inline-text formatters work as in placeholders.  |
| `{{ds.DeliveryDate}:F('d MMM yyyy')}` | Date/number format strings are supported.        |
| `{{(ds.A + ds.B)}}`                   | C# expressions are supported.                    |

```csharp
var template = DocxTemplate.Open("template.docx");
template.BindModel("ds", new { Name = "World", DeliveryDate = new DateTime(2026, 7, 8) });
template.Save("generated.docx");
```

Content controls inside a loop are filled once per iteration (the tag resolves against the loop scope, e.g. `{{ds.Items}}` or `{{.Name}}`); content controls in headers/footers are filled too.

## Semantics

Unlike a text placeholder, a content control is treated as a **named, persistent region**:

- The control and its tag are **never removed** and are preserved in the output, so it stays addressable.
- A tag that **cannot be bound** — unbound (absent) **or resolving to `null`** — **leaves the control unchanged** (under `SkipBindingAndRemoveContent`). This makes **multi-pass filling non-destructive**, including when passes share a model type whose other members are simply `null` rather than absent — a control filled in an earlier pass is never cleared by a later pass.
- The `w:showingPlcHdr` flag is cleared on a successful fill, so Word shows the value as real text.
- Under `ThrowException` an unbound tag throws; under `HighlightErrorsInDocument` the control's content is highlighted **in place without discarding it**.

Robustness / backward compatibility:

- A tag that is **not** a placeholder, is a block directive (`{{#items}}`), or is a **malformed** brace directive (`{{@}}`, `{{/switch}}`, `{{}}`) is **ignored** — it never aborts the render. Existing templates are unaffected (a tag only participates if it contains a valid `{{…}}` placeholder).
- Target text is scoped to the control's **own** content, so a **nested** content control is never consumed or corrupted by an outer one.
- Collapsing multi-paragraph content leaves **no stray empty paragraphs**; the first run's formatting is preserved.
- Only **inline-text** formatters (`ToUpper`, `format`, expressions) are supported on a tag. Block-producing formatters (`html`, `md`, `img`, `template`) are not supported inside a content control (use them as normal body placeholders).

## Implementation

- The work is done in `VariableReplacer.ReplaceVariables(OpenXmlElement, …)`, the single choke point that fills marked text for both the root element and each cloned loop body — so loops (and headers/footers) are handled for free.
- For each `SdtElement` whose tag is a `Variable`/`Expression` placeholder, the value is resolved **before** the content is touched (so an unbound/null tag leaves the control untouched), then written into a single target `Text` via the existing `ApplyFormatter` path.
- The control is never routed through `RemoveWithEmptyParent` in a way that could dissolve it, and target selection excludes text owned by nested controls.

## Tests

New `ContentControlBindingTest` (18 tests) covering: block and inline controls, formatter and expression tags, non-placeholder and malformed tags left untouched, placeholder-in-content, filling inside a loop and in a header, empty controls, multi-paragraph collapse, nested controls, `ThrowException` / `HighlightErrorsInDocument`, bound-null, and the deferred multi-pass scenario with both anonymous and shared model types. Every generated document is asserted valid via `DocxTemplate.Validate()`.

## Docs

README: new **Content Controls** section, a feature-list bullet, and notes on the formatter and `GetTemplateSchema()` limitations (tag bindings are not part of the rendered text, same as sub-templates).
