### PR TITLE
Preserve space in multi-line text

### DIFF
--- a/DocxTemplater.Test/DocxTemplateTest.cs
+++ b/DocxTemplater.Test/DocxTemplateTest.cs
@@ -324,7 +324,7 @@ namespace DocxTemplater.Test
             memStream.Position = 0;
 
             var docTemplate = new DocxTemplate(memStream);
-            docTemplate.BindModel("ds", "FirstLine\r\nSecondLine\nThirdLine");
+            docTemplate.BindModel("ds", " FirstLine\r\n  SecondLine\n   ThirdLine");
             var result = docTemplate.Process();
             docTemplate.Validate();
             Assert.That(result, Is.Not.Null);
@@ -335,9 +335,9 @@ namespace DocxTemplater.Test
             // stays on the same line as "ThirdLine" - a trailing <w:br/> here would push " End"
             // onto a spurious extra line (and, for a value alone in a table cell, add an empty row).
             Assert.That(body.InnerXml, Is.EqualTo("<w:p xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:r><w:t xml:space=\"preserve\">" +
-                                                  "Start </w:t><w:t>FirstLine</w:t>" +
-                                                  "<w:br /><w:t>SecondLine</w:t>" +
-                                                  "<w:br /><w:t>ThirdLine</w:t>" +
+                                                  "Start </w:t><w:t xml:space=\"preserve\"> FirstLine</w:t>" +
+                                                  "<w:br /><w:t xml:space=\"preserve\">  SecondLine</w:t>" +
+                                                  "<w:br /><w:t xml:space=\"preserve\">   ThirdLine</w:t>" +
                                                   "<w:t xml:space=\"preserve\"> End</w:t></w:r></w:p>"));
         }
 

--- a/DocxTemplater.Test/GitHubQuestionsExamples.cs
+++ b/DocxTemplater.Test/GitHubQuestionsExamples.cs
@@ -29,7 +29,7 @@ namespace DocxTemplater.Test
             var body = document.MainDocumentPart.Document.Body;
             Assert.That(body.InnerXml,
                 Is.EqualTo(
-                    @"<w:p xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main""><w:r><w:t>First Line</w:t><w:br /><w:t>Second Line</w:t><w:br /><w:t>Third Line</w:t><w:br /></w:r></w:p>"));
+                    @"<w:p xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main""><w:r><w:t xml:space=""preserve"">First Line</w:t><w:br /><w:t xml:space=""preserve"">Second Line</w:t><w:br /><w:t xml:space=""preserve"">Third Line</w:t><w:br /></w:r></w:p>"));
         }
 
 

--- a/DocxTemplater/Formatter/VariableReplacer.cs
+++ b/DocxTemplater/Formatter/VariableReplacer.cs
@@ -50,7 +50,7 @@ namespace DocxTemplater.Formatter
             {
                 var firstParagraph = rootElement.GetFirstChild<Paragraph>();
                 var paragraph = new Paragraph();
-                var text = new Text(string.Join("\n", m_errors.Distinct()));
+                var text = new Text(string.Join("\n", m_errors.Distinct())) { Space = SpaceProcessingModeValues.Preserve };
                 paragraph.AppendChild(new Run(new RunProperties()
                 {
                     Color = new Color() { Val = "FF0000" },
@@ -469,7 +469,7 @@ namespace DocxTemplater.Formatter
 
                     if (!string.IsNullOrWhiteSpace(parts[i]))
                     {
-                        lastElement = lastElement.InsertAfterSelf(new Text(parts[i]));
+                        lastElement = lastElement.InsertAfterSelf(new Text(parts[i]) { Space = SpaceProcessingModeValues.Preserve });
                     }
                 }
 


### PR DESCRIPTION
The `VariableReplacer` class was missing preserving spaces when replacing a variable with a multi-line text value.

* this PR addresses this issue that could  only be observed when document is rendered
* for consistency's sake all newly created `Text` elements are preserving spaces.