### PR TITLE
Add paragraphs formatter to render multi-line values as real paragraphs

### DIFF
--- a/DocxTemplater.Test/ParagraphsFormatterTest.cs
+++ b/DocxTemplater.Test/ParagraphsFormatterTest.cs
@@ -1,0 +1,193 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocxTemplater.Test
+{
+    /// <summary>
+    /// The 'paragraphs' (alias 'para') formatter renders each line of a multi-line value as its own
+    /// real paragraph (a blank line as an empty paragraph) instead of the default soft line breaks
+    /// (&lt;w:br/&gt;) inside a single paragraph. Soft breaks keep all lines in one paragraph, which
+    /// breaks paragraph-based styling, numbering and downstream tooling that works per paragraph.
+    /// </summary>
+    internal class ParagraphsFormatterTest
+    {
+        [Test]
+        public void MultiLineValue_CreatesOneParagraphPerLine()
+        {
+            using var processed = Render(new Paragraph(new Run(new Text("{{ds.Notes}:paragraphs}"))), "Line1\nLine2\nLine3");
+            var body = processed.MainDocumentPart.Document.Body;
+
+            Assert.That(body.Elements<Paragraph>().Select(p => p.InnerText), Is.EqualTo(["Line1", "Line2", "Line3"]));
+            Assert.That(body.Descendants<Break>(), Is.Empty, "lines must become paragraphs, not soft breaks");
+        }
+
+        [Test]
+        public void BlankLineAndCrLf_BecomeEmptyParagraph()
+        {
+            using var processed = Render(new Paragraph(new Run(new Text("{{ds.Notes}:paragraphs}"))), "Alinea1\r\n\r\nAlinea2");
+            var body = processed.MainDocumentPart.Document.Body;
+
+            Assert.That(body.Elements<Paragraph>().Select(p => p.InnerText), Is.EqualTo(["Alinea1", "", "Alinea2"]));
+            Assert.That(body.Descendants<Break>(), Is.Empty);
+        }
+
+        [Test]
+        public void TrailingNewline_YieldsTrailingEmptyParagraph()
+        {
+            using var processed = Render(new Paragraph(new Run(new Text("{{ds.Notes}:paragraphs}"))), "Last\n");
+            var body = processed.MainDocumentPart.Document.Body;
+
+            Assert.That(body.Elements<Paragraph>().Select(p => p.InnerText), Is.EqualTo(["Last", ""]));
+        }
+
+        [Test]
+        public void SurroundingText_StaysOnFirstAndLastLine()
+        {
+            using var processed = Render(new Paragraph(new Run(new Text("Start {{ds.Notes}:para} End"))), "a\nb");
+            var body = processed.MainDocumentPart.Document.Body;
+
+            Assert.That(body.Elements<Paragraph>().Select(p => p.InnerText), Is.EqualTo(["Start a", "b End"]));
+        }
+
+        [Test]
+        public void SingleLineValue_StaysInline()
+        {
+            using var processed = Render(new Paragraph(new Run(new Text("Start {{ds.Notes}:paragraphs} End"))), "plain");
+            var body = processed.MainDocumentPart.Document.Body;
+
+            Assert.That(body.Elements<Paragraph>().Select(p => p.InnerText), Is.EqualTo(["Start plain End"]));
+        }
+
+        [Test]
+        public void HostParagraphAndRunFormatting_CarryOverToAllLines()
+        {
+            var template = new Paragraph(
+                new ParagraphProperties(new ParagraphStyleId { Val = "Quote" }),
+                new Run(new RunProperties(new Bold()), new Text("{{ds.Notes}:paragraphs}")));
+
+            using var processed = Render(template, "a\nb\nc");
+            var paragraphs = processed.MainDocumentPart.Document.Body.Elements<Paragraph>().ToList();
+
+            Assert.That(paragraphs, Has.Count.EqualTo(3));
+            Assert.That(paragraphs.Select(p => p.ParagraphProperties?.ParagraphStyleId?.Val?.Value),
+                Is.All.EqualTo("Quote"), "every line must keep the host paragraph style");
+            Assert.That(paragraphs.SelectMany(p => p.Descendants<Run>()).Select(r => r.RunProperties?.Bold),
+                Is.All.Not.Null, "every line must keep the placeholder run formatting");
+        }
+
+        [Test]
+        public void EmptyValue_InTableCell_KeepsCellParagraph()
+        {
+            const string content = @"
+<w:tbl xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+  <w:tblPr><w:tblW w:w=""0"" w:type=""auto""/></w:tblPr>
+  <w:tblGrid><w:gridCol w:w=""5000""/></w:tblGrid>
+  <w:tr>
+    <w:tc>
+      <w:tcPr><w:tcW w:w=""5000"" w:type=""dxa""/></w:tcPr>
+      <w:p><w:r><w:t>{{ds.Notes}:paragraphs}</w:t></w:r></w:p>
+    </w:tc>
+  </w:tr>
+</w:tbl>";
+
+            using var memStream = new MemoryStream();
+            using (var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wpDocument.AddMainDocumentPart();
+                mainPart.Document = new Document { Body = new Body { InnerXml = content } };
+                wpDocument.Save();
+            }
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { Notes = string.Empty });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+
+            using var processed = WordprocessingDocument.Open(result, false);
+            var cell = processed.MainDocumentPart.Document.Body.Descendants<TableCell>().Single();
+            Assert.That(cell.Elements<Paragraph>().Count(), Is.EqualTo(1), "the cell must keep its paragraph");
+        }
+
+        [Test]
+        public void InsideLoop_ExpandsPerIteration()
+        {
+            using var memStream = new MemoryStream();
+            using (var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wpDocument.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body(
+                    new Paragraph(new Run(new Text("{{#ds.Items}}"))),
+                    new Paragraph(new Run(new Text("{{.Value}:paragraphs}"))),
+                    new Paragraph(new Run(new Text("{{/ds.Items}}")))));
+                wpDocument.Save();
+            }
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { Items = new[] { new { Value = "a\nb" }, new { Value = "c\nd" } } });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+
+            using var processed = WordprocessingDocument.Open(result, false);
+            var texts = processed.MainDocumentPart.Document.Body.Elements<Paragraph>()
+                .Select(p => p.InnerText)
+                .Where(t => t.Length > 0)
+                .ToList();
+            Assert.That(texts, Is.EqualTo(["a", "b", "c", "d"]));
+        }
+
+        [Test]
+        public void InsideInlineContentControl_FallsBackToSoftBreaks()
+        {
+            const string content = @"
+<w:p xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+  <w:sdt>
+    <w:sdtPr><w:tag w:val=""notes""/></w:sdtPr>
+    <w:sdtContent><w:r><w:t>{{ds.Notes}:paragraphs}</w:t></w:r></w:sdtContent>
+  </w:sdt>
+</w:p>";
+
+            using var memStream = new MemoryStream();
+            using (var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wpDocument.AddMainDocumentPart();
+                mainPart.Document = new Document { Body = new Body { InnerXml = content } };
+                wpDocument.Save();
+            }
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { Notes = "a\nb" });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+
+            using var processed = WordprocessingDocument.Open(result, false);
+            var body = processed.MainDocumentPart.Document.Body;
+
+            // Splitting a run-level content control would duplicate it; the value degrades to soft breaks.
+            Assert.That(body.Elements<Paragraph>().Count(), Is.EqualTo(1));
+            Assert.That(body.Descendants<Break>().Count(), Is.EqualTo(1));
+            Assert.That(body.InnerText, Does.Contain("a").And.Contain("b"));
+        }
+
+        private static WordprocessingDocument Render(Paragraph templateParagraph, string notes)
+        {
+            var memStream = new MemoryStream();
+            using (var wpDocument = WordprocessingDocument.Create(memStream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wpDocument.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body(templateParagraph));
+                wpDocument.Save();
+            }
+            memStream.Position = 0;
+
+            var docTemplate = new DocxTemplate(memStream);
+            docTemplate.BindModel("ds", new { Notes = notes });
+            var result = docTemplate.Process();
+            docTemplate.Validate();
+            return WordprocessingDocument.Open(result, false);
+        }
+    }
+}

--- a/DocxTemplater/Formatter/ParagraphsFormatter.cs
+++ b/DocxTemplater/Formatter/ParagraphsFormatter.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocxTemplater.Formatter
+{
+    /// <summary>
+    /// Renders a multi-line string value as real paragraphs: each line of the value becomes its own
+    /// paragraph (a blank line an empty paragraph), inheriting the paragraph and run properties of the
+    /// placeholder. Without this formatter, newlines in a value are rendered as soft line breaks
+    /// (<c>w:br</c>) inside a single paragraph.
+    /// </summary>
+    internal class ParagraphsFormatter : IFormatter
+    {
+        public bool CanHandle(Type type, string prefix)
+        {
+            if (type == typeof(string))
+            {
+                return prefix.Equals("paragraphs", StringComparison.OrdinalIgnoreCase) || prefix.Equals("para", StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
+        }
+
+        public void ApplyFormat(ITemplateProcessingContext templateContext, FormatterContext formatterContext,
+            Text target)
+        {
+            if (formatterContext.Value is not string value)
+            {
+                throw new OpenXmlTemplateException($"Formatter {formatterContext.Formatter} can only be applied to string objects - property {formatterContext.Placeholder}");
+            }
+
+            if (value.Length == 0)
+            {
+                // Keep the (possibly last) paragraph in place - removing it could leave a table cell empty.
+                target.Text = string.Empty;
+                return;
+            }
+
+            var lines = value.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+            var hostParagraph = target.GetFirstAncestor<Paragraph>();
+
+            // Single-line values need no splitting. Without a host paragraph, or inside an inline (run
+            // level) content control, splitting would corrupt the surrounding structure - write the raw
+            // value instead and let the caller's newline handling degrade to soft line breaks.
+            if (lines.Length == 1 || hostParagraph == null || IsInsideInlineSdt(target, hostParagraph))
+            {
+                target.Text = value;
+                target.Space = SpaceProcessingModeValues.Preserve;
+                return;
+            }
+
+            var paragraphProperties = hostParagraph.GetFirstChild<ParagraphProperties>();
+            var runProperties = target.GetFirstAncestor<Run>()?.RunProperties;
+
+            // Text before the placeholder stays with the first line; text after it goes with the last.
+            var split = hostParagraph.SplitAfterElement(target);
+            var firstParagraph = split.OfType<Paragraph>().First();
+            var lastParagraph = split.OfType<Paragraph>().Last();
+
+            target.Text = lines[0];
+            target.Space = SpaceProcessingModeValues.Preserve;
+
+            // The split-off paragraph is a shallow clone without the host's paragraph properties; restore
+            // them so the text after the placeholder keeps its original formatting.
+            if (lastParagraph != firstParagraph && paragraphProperties != null && lastParagraph.GetFirstChild<ParagraphProperties>() == null)
+            {
+                lastParagraph.PrependChild(paragraphProperties.CloneNode(true));
+            }
+
+            var ownParagraphLines = lastParagraph != firstParagraph ? lines.Length - 1 : lines.Length;
+            OpenXmlElement anchor = firstParagraph;
+            for (int i = 1; i < ownParagraphLines; i++)
+            {
+                var paragraph = new Paragraph();
+                if (paragraphProperties != null)
+                {
+                    paragraph.AppendChild(paragraphProperties.CloneNode(true));
+                }
+                if (lines[i].Length > 0)
+                {
+                    paragraph.AppendChild(CreateRun(runProperties, lines[i]));
+                }
+                anchor = anchor.InsertAfterSelf(paragraph);
+            }
+
+            if (lastParagraph != firstParagraph && lines[^1].Length > 0)
+            {
+                var run = CreateRun(runProperties, lines[^1]);
+                var lastParagraphProperties = lastParagraph.GetFirstChild<ParagraphProperties>();
+                if (lastParagraphProperties != null)
+                {
+                    lastParagraphProperties.InsertAfterSelf(run);
+                }
+                else
+                {
+                    lastParagraph.PrependChild(run);
+                }
+            }
+        }
+
+        private static Run CreateRun(RunProperties runProperties, string text)
+        {
+            var run = new Run();
+            if (runProperties != null)
+            {
+                run.AppendChild((RunProperties)runProperties.CloneNode(true));
+            }
+            run.AppendChild(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
+            return run;
+        }
+
+        private static bool IsInsideInlineSdt(Text target, Paragraph hostParagraph)
+        {
+            for (var parent = target.Parent; parent != null && parent != hostParagraph; parent = parent.Parent)
+            {
+                if (parent is SdtElement)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/DocxTemplater/Formatter/VariableReplacer.cs
+++ b/DocxTemplater/Formatter/VariableReplacer.cs
@@ -22,6 +22,7 @@ namespace DocxTemplater.Formatter
             m_formatters.Add(new FormatPatternFormatter());
             m_formatters.Add(new HtmlFormatter());
             m_formatters.Add(new CaseFormatter());
+            m_formatters.Add(new ParagraphsFormatter());
         }
 
         public ProcessSettings ProcessSettings

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The syntax is case insensitive.
 | `{{(ds.Items[0].Name)}}`                                 | Expressions with array / list / dictionary index access.                                        |
 | `{{SomeBytes}:img()}`                                    | Image Formatter for image data.                                                                 |
 | `{{SomeHtmlString}:html()}`                              | Inserts HTML string into the word document.                                                     |
+| `{{MultiLineText}:paragraphs()}`                         | Renders each line of a multi-line string as its own paragraph instead of soft line breaks.     |
 | `{{ds}:template('ds.SubDocument')}`                      | Inserts another docx document (or OpenXML fragment) at the placeholder position.               |
 | `{{@i:ItemCount}}...{{i}}...{{/}}`                       | Range loop that repeats its content `ItemCount` times.                                          |
 | `{{#Items}}{?{Items._Idx % 2 == 0}}{{.}}{{/}}{{/Items}}` | Renders every second item in a list.                                                            |
@@ -287,6 +288,18 @@ The formatter name is always case insensitive.
 
 - `ToUpper`
 - `ToLower`
+
+### Paragraphs
+
+By default, newlines in a value are rendered as soft line breaks (`<w:br/>`) inside a single paragraph.
+The `paragraphs` formatter (alias `para`) renders each line of a multi-line string as its own real paragraph instead — a blank line becomes an empty paragraph.
+All created paragraphs inherit the paragraph and run properties of the placeholder, so styles, numbering and run formatting carry over to every line.
+
+```
+{{MultiLineText}:paragraphs()}
+```
+
+Text before or after the placeholder in the same paragraph is preserved: it stays with the first and last line respectively.
 
 ### FormatPatterns
 


### PR DESCRIPTION
Currently a newline in a bound value is always rendered as a soft line break (`<w:br/>`) inside a single paragraph (`SplitNewLinesInText`). That keeps all lines in one `w:p`, which loses paragraph-based styling/numbering and reads as one glued block for downstream tooling that works per paragraph.

This PR adds an opt-in built-in formatter — `{{Value}:paragraphs()}` (alias `:para`) — that renders each line of a multi-line string as its own paragraph, cloning the placeholder's paragraph and run properties onto every line; a blank line becomes an empty paragraph. Text before/after the placeholder stays with the first/last line (same `SplitAfterElement` approach as the Markdown formatter).

Details:
- Empty values keep their paragraph, so a table cell never loses its last paragraph.
- Inside a run-level content control the value falls back to the existing soft-break behavior (splitting would duplicate the control).
- Registered in the `VariableReplacer` constructor so it also works inside sub-templates.
- No behavior change for existing templates — the default soft-break rendering is untouched.

Includes 9 tests and README docs. Full solution builds warning-clean in Release; all existing tests pass (457 core tests across net8.0/net9.0/net10.0, plus the Images/ImageSharp test projects).